### PR TITLE
Upgrade to Kotlin 2.4.0 + ksrpc 1.1.1 (0.4.1)

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -182,11 +182,11 @@ in scope, the spelled-out type is `suspend FlowCollector<String>.(Box) -> Unit`.
 
 ## ksrpc dependency
 
-`hauler` 0.4.0 depends on `com.monkopedia.ksrpc:ksrpc-core:1.0.0` (stable).
-ksrpc is API-stable under semver from 1.0.0 onward.
+`hauler` 0.4.1 depends on `com.monkopedia.ksrpc:ksrpc-core:1.1.1` (stable),
+built with Kotlin 2.4.0. ksrpc is API-stable under semver from 1.0.0 onward.
 
 If your project applies the `com.monkopedia.ksrpc.plugin` Gradle plugin
-directly, also bump it to `1.0.0`. If you reference `ksrpc-sockets` /
+directly, also bump it to `1.1.1`. If you reference `ksrpc-sockets` /
 `ksrpc-ktor-client` / `ksrpc-ktor-websocket-client` directly, the entry-point
 names changed in ksrpc 1.0:
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.js.webpack.major.version=4
-version=0.4.0
+version=0.4.1
 signing.gnupg.keyName=5B83421E2338B907
 org.gradle.jvmargs=-Xmx4096m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,9 @@
 [versions]
-kotlin = "2.3.20"
+kotlin = "2.4.0"
 kotlin-coroutines = "1.10.2"
 kotlin-serialization = "1.10.0"
 kotlin-datetime = "0.7.1"
 kotlin-nodejs = "0.0.7"
-ksp = "2.3.6"
 ktor = "3.4.1"
 slf4j = "2.0.17"
 clikt = "5.1.0"
@@ -12,10 +11,8 @@ gradleplugin = "9.1.0"
 kotlin-atomicfu = "0.31.0"
 kotlin-compiletesting = "1.6.0"
 dokka = "2.1.0"
-googleautoservice = "1.1.1"
-autoservice-ksp = "1.2.0"
 jnanoid = "2.0.0"
-ksrpc = "1.0.0"
+ksrpc = "1.1.1"
 hierynomus = "0.16.1"
 ktlint-formatter = "1.8.0"
 ktlint-plugin = "14.2.0"
@@ -29,8 +26,6 @@ vannik = "0.36.0"
 dokka-base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
 dokka-gradle = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-autoservice = { module = "dev.zacsweers.autoservice:auto-service-ksp", version.ref = "autoservice-ksp" }
-autoservice-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "googleautoservice" }
 kotlin-compiletesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "kotlin-compiletesting"}
 ktor-io = { module = "io.ktor:ktor-io", version.ref = "ktor" }
 kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlin-serialization"}
@@ -81,7 +76,6 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 hierynomus-license = { id = "com.github.hierynomus.license", version.ref = "hierynomus" }
 jlleitschuh-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-plugin" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp"}
 kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
 kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark" }
 gmazzo-buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }

--- a/hauler/api/hauler.api
+++ b/hauler/api/hauler.api
@@ -82,9 +82,9 @@ public final class com/monkopedia/hauler/BasicDeliveryService$Stub$AnonymousWeig
 
 public final synthetic class com/monkopedia/hauler/BasicDeliveryService$Stub$Companion {
 	public fun <init> ()V
-	public final synthetic fun DumpCustomerPickup$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
-	public final synthetic fun RecurringCustomerPickup$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
-	public final synthetic fun WeighIn$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun DumpCustomerPickup$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun RecurringCustomerPickup$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun WeighIn$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
 }
 
 public abstract interface class com/monkopedia/hauler/BasicShipper : com/monkopedia/ksrpc/RpcHostService {
@@ -130,8 +130,8 @@ public final class com/monkopedia/hauler/BasicShipper$Stub$AnonymousRequestPicku
 
 public final synthetic class com/monkopedia/hauler/BasicShipper$Stub$Companion {
 	public fun <init> ()V
-	public final synthetic fun RequestDockPickup$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
-	public final synthetic fun RequestPickup$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun RequestDockPickup$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun RequestPickup$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
 }
 
 public final class com/monkopedia/hauler/Box {
@@ -237,7 +237,7 @@ public final class com/monkopedia/hauler/CustomerPickup$Stub$AnonymousGet : com/
 
 public final synthetic class com/monkopedia/hauler/CustomerPickup$Stub$Companion {
 	public fun <init> ()V
-	public final synthetic fun Get$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun Get$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
 }
 
 public final class com/monkopedia/hauler/DeliveryRates {
@@ -330,13 +330,13 @@ public final class com/monkopedia/hauler/DeliveryService$Stub$AnonymousWeighIn :
 
 public final synthetic class com/monkopedia/hauler/DeliveryService$Stub$Companion {
 	public fun <init> ()V
-	public final synthetic fun DumpCustomerPickup$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
-	public final synthetic fun DumpDeliveries$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
-	public final synthetic fun DumpDeliveriesPacked$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
-	public final synthetic fun RecurringCustomerPickup$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
-	public final synthetic fun StreamDeliveries$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
-	public final synthetic fun StreamDeliveriesPacked$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
-	public final synthetic fun WeighIn$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun DumpCustomerPickup$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun DumpDeliveries$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun DumpDeliveriesPacked$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun RecurringCustomerPickup$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun StreamDeliveries$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun StreamDeliveriesPacked$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun WeighIn$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
 }
 
 public abstract interface class com/monkopedia/hauler/DropBox : com/monkopedia/ksrpc/RpcService {
@@ -371,7 +371,7 @@ public final class com/monkopedia/hauler/DropBox$Stub$AnonymousLog : com/monkope
 
 public final synthetic class com/monkopedia/hauler/DropBox$Stub$Companion {
 	public fun <init> ()V
-	public final synthetic fun Log$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun Log$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
 }
 
 public final class com/monkopedia/hauler/FilterBuilderKt {
@@ -537,7 +537,7 @@ public final class com/monkopedia/hauler/LoadingDock$Stub$AnonymousBulkLog : com
 
 public final synthetic class com/monkopedia/hauler/LoadingDock$Stub$Companion {
 	public fun <init> ()V
-	public final synthetic fun BulkLog$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun BulkLog$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
 }
 
 public abstract class com/monkopedia/hauler/LoggerMatchMode : java/lang/Enum {
@@ -799,9 +799,9 @@ public final class com/monkopedia/hauler/Shipper$Stub$AnonymousRequestPickup : c
 
 public final synthetic class com/monkopedia/hauler/Shipper$Stub$Companion {
 	public fun <init> ()V
-	public final synthetic fun Deliveries$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
-	public final synthetic fun RequestDockPickup$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
-	public final synthetic fun RequestPickup$hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun Deliveries$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun RequestDockPickup$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
+	public final synthetic fun RequestPickup$com_monkopedia_hauler ()Lcom/monkopedia/ksrpc/RpcMethod;
 }
 
 public final class com/monkopedia/hauler/TerminatorsKt {


### PR DESCRIPTION
## Summary

Patch release (0.4.1): Kotlin toolchain + ksrpc dependency bump. No source or public-API change.

- **Kotlin 2.3.20 → 2.4.0**
- **ksrpc 1.0.0 → 1.1.1** — the ksrpc Gradle plugin version flows from `libs.versions.ksrpc` via the buildscript classpath, so this single catalog edit moves both the library and the 2.4.0-rebuilt plugin.
- **Removed vestigial KSP / auto-service catalog entries** (`ksp` version+plugin, `googleautoservice`, `autoservice-ksp`, and the `auto-service` libraries). hauler never applied KSP — no `@AutoService` annotations, no `ksp()` deps, no `kspKotlin` tasks, no generated `META-INF/services` — so these were dead declarations. (Unlike ksrpc, hauler had no KSP wall to clear.)
- **MIGRATING.md** ksrpc-dependency note updated to cite 1.1.1 / Kotlin 2.4.0.

## API dump

The only `hauler.api` diff is ksrpc 1.1.1's codegen changing the **synthetic** stub-accessor module suffix from `$hauler` to `$com_monkopedia_hauler` on the generated `$Stub$Companion` classes. These are JVM-synthetic internal `RpcMethod` accessors, **not source-visible API** — zero real public symbols added/removed/changed, user-facing interfaces untouched. No-op for consumers. (Same class of churn ksrpc addressed with BCV synthetic exclusions in its #208; hauler could adopt the same exclusion as a future cleanup so this stops churning the dump.)

## Verification

- Build + tests green on JVM / JS (nodejs) / WASM (nodejs).
- Compile clean on all native targets: Linux x64 + arm64, mingwX64, macOS arm64/x64, iOS arm64/x64/simulatorArm64.
- `:hauler:apiCheck` clean (dump refreshed).
- `kotlin-js-store/yarn.lock` actualized via `kotlinUpgradeYarnLock`; produced no net diff against the committed lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)