### PR TITLE
Remove vestigial `inline` from non-inlinable log helpers (#2)

### DIFF
--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Garage.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Garage.kt
@@ -45,7 +45,7 @@ object Garage {
 }
 
 /** Create a [Hauler] that tags all emitted [Box]es with the given [loggerName]. */
-inline fun Hauler.named(loggerName: String): Hauler =
+fun Hauler.named(loggerName: String): Hauler =
     Hauler { box ->
         this@named.emit(
             Box(box.level, loggerName, box.message, box.timestamp, box.threadName, box.metadata),
@@ -53,29 +53,29 @@ inline fun Hauler.named(loggerName: String): Hauler =
     }
 
 /** Create a [Hauler] that only emits [Box]es at or above the given [level]. */
-inline fun Hauler.level(level: Level): Hauler =
+fun Hauler.level(level: Level): Hauler =
     Hauler { box ->
         if (box.level.intLevel >= level.intLevel) {
             this@level.emit(box)
         }
     }
 
-inline fun Deliveries.level(level: Level): Deliveries =
+fun Deliveries.level(level: Level): Deliveries =
     filter { box ->
         box.level.intLevel >= level.intLevel
     }
 
 /** Create a named [Hauler] that routes through the global [Garage]. */
-inline fun hauler(name: String): Hauler = Garage.rootHauler.named(name)
+fun hauler(name: String): Hauler = Garage.rootHauler.named(name)
 
 inline fun <reified T> T.hauler(): Hauler = createHauler<T>()
 
 inline fun <reified T> createHauler(): Hauler = hauler(T::class.simpleName ?: T::class.toString())
 
-inline fun route(
+fun route(
     scope: CoroutineScope,
     display: Display,
-    noinline formatter: Formatter = FlowCollector<String>::defaultFormat,
+    formatter: Formatter = FlowCollector<String>::defaultFormat,
 ): Job =
     scope.launch {
         Garage.deliveries.route(display, formatter)

--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Hauler.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Hauler.kt
@@ -112,38 +112,38 @@ interface AsyncHauler {
  */
 expect fun loggingName(): String?
 
-inline fun AsyncHauler.ship(
+fun AsyncHauler.ship(
     level: Level,
     message: String,
     throwable: Throwable? = null,
     metadata: Map<String, String>? = null,
 ) = emit(convert(level, message, throwable, loggingName(), metadata))
 
-inline fun AsyncHauler.error(
+fun AsyncHauler.error(
     message: String,
     throwable: Throwable? = null,
     metadata: Map<String, String>? = null,
 ) = ship(ERROR, message, throwable, metadata)
 
-inline fun AsyncHauler.warn(
+fun AsyncHauler.warn(
     message: String,
     throwable: Throwable? = null,
     metadata: Map<String, String>? = null,
 ) = ship(WARN, message, throwable, metadata)
 
-inline fun AsyncHauler.info(
+fun AsyncHauler.info(
     message: String,
     throwable: Throwable? = null,
     metadata: Map<String, String>? = null,
 ) = ship(INFO, message, throwable, metadata)
 
-inline fun AsyncHauler.debug(
+fun AsyncHauler.debug(
     message: String,
     throwable: Throwable? = null,
     metadata: Map<String, String>? = null,
 ) = ship(DEBUG, message, throwable, metadata)
 
-inline fun AsyncHauler.trace(
+fun AsyncHauler.trace(
     message: String,
     throwable: Throwable? = null,
     metadata: Map<String, String>? = null,


### PR DESCRIPTION
## Summary
Removes the `inline` modifier from 11 public functions that have no inlinable function-type parameter. On Kotlin 2.4.0 each emits:

```
w: Expected performance impact from inlining is insignificant. Inlining works best for functions with parameters of function types.
```

Authoritative compiler output confirmed exactly 11 such warnings before this change, **0 after**:
- `Garage.kt`: `named`, `Hauler.level`, `Deliveries.level`, `hauler(name)`, `route(scope, …)`
- `Hauler.kt`: `AsyncHauler.ship`, `error`, `warn`, `info`, `debug`, `trace`

`route(scope, …)`'s `formatter` was `noinline`; that modifier is only valid inside an `inline` function, so it's dropped alongside.

## Deliberately left intact
- The **`reified`** helpers `hauler<T>()` / `createHauler<T>()` — `inline` is required for reified type params (not flagged).
- The **`suspend inline`** `Hauler.ship`/`error`/`warn`/`info`/`debug`/`trace` set — not flagged; `ship` references the `@PublishedApi internal convert`, so removing `inline` there would have ABI implications. Out of scope.
- The `suspend inline route(display, formatter)` overload — not flagged.

## Binary safety / BCV
`inline` is not part of the JVM signature, so this is the binary-safe direction: old consumers keep their already-inlined copies and `:hauler:apiCheck` is unchanged. Verified clean (JVM apiCheck passes; native klib BCV check is host-skipped on Linux as usual — CI on macos-latest covers it).

## Verification (JDK 21)
- `:hauler:allTests` green on all host-runnable targets: `jvmTest`, `jsNodeTest`, `wasmJsNodeTest`, `linuxX64Test` (macos/ios/mingw are host-skipped on Linux; CI covers).
- `:hauler:apiCheck` ✅ — no public-API delta.
- 11 → 0 "insignificant inlining" warnings.

## Note for reviewer (pre-existing, NOT in this PR)
`:hauler:build` currently fails its `ktlintCheck` gate on **22 pre-existing style violations across 6 files** (Conversions, CustomerPickupImpl, FilterBuilder, Filters, Garage:44, Terminators) — these are on `main`, unrelated to this change (hauler's publish-only CI never ran ktlint, so they accumulated). This PR introduces **zero** new ktlint violations and deliberately does not bundle drive-by style fixes. Worth a separate `ktlintFormat` cleanup PR if desired.

Fixes #2