### PR TITLE
Remove unused JVM runtime dependencies (#3)

### DIFF
--- a/hauler/build.gradle.kts
+++ b/hauler/build.gradle.kts
@@ -61,14 +61,10 @@ kotlin {
     }
     sourceSets["jvmMain"].dependencies {
         implementation(kotlin("stdlib"))
-        implementation(kotlin("reflect"))
-        implementation(libs.slf4j.api)
         compileOnly(libs.ktor.server)
         compileOnly(libs.ktor.server.host.common)
         compileOnly(libs.ktor.server.netty)
         compileOnly(libs.ktor.client)
-        implementation(libs.clikt)
-        implementation(libs.logback.classic)
     }
     sourceSets["commonTest"].dependencies {
         implementation(kotlin("test"))


### PR DESCRIPTION
## Summary
Removes four `implementation` dependencies from the `jvmMain` source set that nothing in the code references:
- `kotlin("reflect")`
- `libs.slf4j.api`
- `libs.clikt`
- `libs.logback.classic`

`jvmMain` is just `HaulerImpl.kt` + `CallSign.kt`. A grep across `hauler/src` finds **zero** references to kotlin reflection (`kotlin.reflect`/`KClass`/`::class.java`/`.javaClass`), slf4j (`org.slf4j`/`LoggerFactory`), clikt (`com.github.ajalt`/`clikt`), or logback (`ch.qos`/`logback`).

## Why it matters
These are `implementation` deps, so they leak onto the **runtime classpath of every JVM consumer** of the published artifact:
- `logback-classic` forces a concrete SLF4J binding onto consumers — a logging *library* should never pin a binding.
- `clikt` (a CLI framework) and `kotlin-reflect` are clearly vestigial from an earlier project shape.

Removing them shrinks the published POM's runtime dependency list and avoids surprising classpath collisions downstream.

## Deliberately kept
- The `compileOnly` ktor-server/host-common/netty/client entries — consumer-wired transport surface, not runtime deps.
- `jsMain`'s `api(libs.ktor.client*)` — intentional re-export.
- The version-catalog entries themselves are left in place (they may be referenced by other modules; this PR only touches hauler's runtime deps).

## Verification (JDK 21)
- `:hauler:compileKotlinJvm` ✅, `:hauler:jvmTest` ✅ — nothing transitively relied on the removed deps.
- `:hauler:apiCheck` ✅ — no source/ABI change; this is POM-metadata only (no apiDump/klib delta).

Fixes #3