### PR TITLE
Suppress expect/actual-classes Beta warning via -Xexpect-actual-classes (#4)

### DIFF
--- a/hauler/build.gradle.kts
+++ b/hauler/build.gradle.kts
@@ -80,7 +80,7 @@ kotlin {
     }
 
     compilerOptions {
-        freeCompilerArgs.addAll("-Xskip-prerelease-check")
+        freeCompilerArgs.addAll("-Xskip-prerelease-check", "-Xexpect-actual-classes")
     }
 }
 


### PR DESCRIPTION
## Summary
Adds `-Xexpect-actual-classes` to `compilerOptions.freeCompilerArgs` (next to the existing `-Xskip-prerelease-check`).

`CallSign` is the project's only `expect class`, so every source set's compile emits:
```
w: 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta. Consider using the '-Xexpect-actual-classes' flag to suppress this warning. (KT-61573)
```
(everything else uses `expect fun`, which is not flagged.) Opting into the flag acknowledges the Beta feature intentionally and clears the warning across all source sets in one line.

## Scope — Option 1 only (per the #4 decision)
This is deliberately the **flag-only** fix. The alternative (Option 2 — restructuring `CallSign` to remove the `expect class` entirely) was explicitly **declined**: it would change `CallSign`'s declared supertypes/structure across platforms, i.e. a **klib-ABI change**, which we are not taking on for a Beta-status warning. No source change to `CallSign` here.

## Verification (JDK 21)
- Beta warning count: **before = 4** (CallSign.kt commonMain:34/37, jvmMain:22/26), **after = 0** — confirmed across `compileKotlinMetadata`, `compileKotlinJvm`, `compileKotlinJs`, `compileKotlinWasmJs`, `compileKotlinLinuxX64`.
- `:hauler:apiCheck` ✅ — metadata-only, no apiDump/klib delta.

Fixes #4