### PR TITLE
Bring the codebase to ktlint-clean (ktlintFormat pass)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,9 @@ repositories {
     mavenCentral()
 }
 
-val ktlintCoreVersion = libs.versions.ktlint.formatter.get()
+val ktlintCoreVersion =
+    libs.versions.ktlint.formatter
+        .get()
 
 subprojects {
     repositories {

--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Conversions.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Conversions.kt
@@ -33,14 +33,16 @@ fun List<Box>.pack(): Palette {
     val threadsList = mutableListOf<String>()
     val packages = ArrayList<Package>(size)
     for (box in this) {
-        val tagIdx = tagsIndex.getOrPut(box.loggerName) {
-            tagsList.size.also { tagsList.add(box.loggerName) }
-        }
-        val threadIdx = box.threadName?.let { name ->
-            threadsIndex.getOrPut(name) {
-                threadsList.size.also { threadsList.add(name) }
+        val tagIdx =
+            tagsIndex.getOrPut(box.loggerName) {
+                tagsList.size.also { tagsList.add(box.loggerName) }
             }
-        }
+        val threadIdx =
+            box.threadName?.let { name ->
+                threadsIndex.getOrPut(name) {
+                    threadsList.size.also { threadsList.add(name) }
+                }
+            }
         packages.add(
             Package(box.level.intLevel, tagIdx, box.message, box.timestamp, threadIdx, box.metadata),
         )

--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/CustomerPickupImpl.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/CustomerPickupImpl.kt
@@ -45,15 +45,16 @@ internal class CustomerPickupImpl(
     }
 
     override suspend fun get(maxEntries: Int): Palette {
-        val items = lock.withLock {
-            val all = circBuffer.toListAndClear()
-            if (all.size > maxEntries) {
-                all.drop(maxEntries).forEach { circBuffer.add(it) }
-                all.take(maxEntries)
-            } else {
-                all
+        val items =
+            lock.withLock {
+                val all = circBuffer.toListAndClear()
+                if (all.size > maxEntries) {
+                    all.drop(maxEntries).forEach { circBuffer.add(it) }
+                    all.take(maxEntries)
+                } else {
+                    all
+                }
             }
-        }
         return items.pack()
     }
 

--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/FilterBuilder.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/FilterBuilder.kt
@@ -22,23 +22,38 @@ annotation class FilterDsl
 class WeighStationBuilder internal constructor() {
     private val filters = mutableListOf<WeighStation>()
 
-    fun level(mode: LevelMatchMode, level: Level) {
+    fun level(
+        mode: LevelMatchMode,
+        level: Level,
+    ) {
         filters.add(LevelFilter(mode, level))
     }
 
-    fun logger(mode: LoggerMatchMode, query: String) {
+    fun logger(
+        mode: LoggerMatchMode,
+        query: String,
+    ) {
         filters.add(LoggerNameFilter(mode, query))
     }
 
-    fun thread(mode: LoggerMatchMode, query: String) {
+    fun thread(
+        mode: LoggerMatchMode,
+        query: String,
+    ) {
         filters.add(ThreadNameFilter(mode, query))
     }
 
-    fun message(mode: LoggerMatchMode, query: String) {
+    fun message(
+        mode: LoggerMatchMode,
+        query: String,
+    ) {
         filters.add(MessageFilter(mode, query))
     }
 
-    fun time(mode: LevelMatchMode, timestamp: Long) {
+    fun time(
+        mode: LevelMatchMode,
+        timestamp: Long,
+    ) {
         filters.add(TimeFilter(mode, timestamp))
     }
 
@@ -65,5 +80,4 @@ class WeighStationBuilder internal constructor() {
     }
 }
 
-fun weighStation(block: WeighStationBuilder.() -> Unit): WeighStation =
-    WeighStationBuilder().apply(block).build()
+fun weighStation(block: WeighStationBuilder.() -> Unit): WeighStation = WeighStationBuilder().apply(block).build()

--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Filters.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Filters.kt
@@ -15,8 +15,8 @@
  */
 package com.monkopedia.hauler
 
-import kotlin.concurrent.Volatile
 import kotlinx.serialization.Serializable
+import kotlin.concurrent.Volatile
 
 /**
  * Monitors truck contents, regulates what gets through.

--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Garage.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Garage.kt
@@ -41,7 +41,6 @@ object Garage {
             sharedFlow.tryEmit(box)
         }
     val deliveries: Deliveries = sharedFlow
-
 }
 
 /** Create a [Hauler] that tags all emitted [Box]es with the given [loggerName]. */

--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Terminators.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Terminators.kt
@@ -56,14 +56,15 @@ suspend fun FlowCollector<String>.defaultFormat(box: Box) {
         Instant
             .fromEpochMilliseconds(box.timestamp)
             .toLocalDateTime(defaultTimeZone)
-    val prefix = buildString {
-        append(time)
-        append(" (")
-        append(box.threadName)
-        append(") ")
-        append(box.loggerName)
-        append(" - ")
-    }
+    val prefix =
+        buildString {
+            append(time)
+            append(" (")
+            append(box.threadName)
+            append(") ")
+            append(box.loggerName)
+            append(" - ")
+        }
     for (line in box.message.split('\n')) {
         emit(prefix + line)
     }

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/AsyncHaulerTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/AsyncHaulerTest.kt
@@ -24,7 +24,6 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
 class AsyncHaulerTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",
@@ -34,95 +33,101 @@ class AsyncHaulerTest {
     ) = Box(level, loggerName, message, timestamp, threadName)
 
     @Test
-    fun asyncHauler_emitsToUnderlying() = runTest {
-        val collected = mutableListOf<Box>()
-        val hauler = Hauler { collected.add(it) }
-        val async = hauler.asAsync(this)
+    fun asyncHauler_emitsToUnderlying() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+            val async = hauler.asAsync(this)
 
-        val testBox = box(message = "async test")
-        async.emit(testBox)
-        withTimeout(2.seconds) {
-            while (collected.isEmpty()) delay(10)
+            val testBox = box(message = "async test")
+            async.emit(testBox)
+            withTimeout(2.seconds) {
+                while (collected.isEmpty()) delay(10)
+            }
+            assertEquals(1, collected.size)
+            assertEquals("async test", collected[0].message)
         }
-        assertEquals(1, collected.size)
-        assertEquals("async test", collected[0].message)
-    }
 
     @Test
-    fun asyncHauler_multipleEmissions() = runTest {
-        val collected = mutableListOf<Box>()
-        val hauler = Hauler { collected.add(it) }
-        val async = hauler.asAsync(this)
+    fun asyncHauler_multipleEmissions() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+            val async = hauler.asAsync(this)
 
-        repeat(5) { i ->
-            async.emit(box(message = "msg$i"))
+            repeat(5) { i ->
+                async.emit(box(message = "msg$i"))
+            }
+            withTimeout(2.seconds) {
+                while (collected.size < 5) delay(10)
+            }
+            assertEquals(5, collected.size)
         }
-        withTimeout(2.seconds) {
-            while (collected.size < 5) delay(10)
-        }
-        assertEquals(5, collected.size)
-    }
 
     @Test
-    fun asyncHauler_shipSetsLevel() = runTest {
-        val collected = mutableListOf<Box>()
-        val hauler = Hauler { collected.add(it) }
-        val async = hauler.asAsync(this)
+    fun asyncHauler_shipSetsLevel() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+            val async = hauler.asAsync(this)
 
-        async.ship(Level.ERROR, "error msg")
-        withTimeout(2.seconds) {
-            while (collected.isEmpty()) delay(10)
+            async.ship(Level.ERROR, "error msg")
+            withTimeout(2.seconds) {
+                while (collected.isEmpty()) delay(10)
+            }
+            assertEquals(Level.ERROR, collected[0].level)
+            assertTrue(collected[0].message.contains("error msg"))
         }
-        assertEquals(Level.ERROR, collected[0].level)
-        assertTrue(collected[0].message.contains("error msg"))
-    }
 
     @Test
-    fun asyncHauler_levelShortcuts() = runTest {
-        val collected = mutableListOf<Box>()
-        val hauler = Hauler { collected.add(it) }
-        val async = hauler.asAsync(this)
+    fun asyncHauler_levelShortcuts() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+            val async = hauler.asAsync(this)
 
-        async.error("e")
-        async.warn("w")
-        async.info("i")
-        async.debug("d")
-        async.trace("t")
+            async.error("e")
+            async.warn("w")
+            async.info("i")
+            async.debug("d")
+            async.trace("t")
 
-        withTimeout(2.seconds) {
-            while (collected.size < 5) delay(10)
+            withTimeout(2.seconds) {
+                while (collected.size < 5) delay(10)
+            }
+            assertEquals(Level.ERROR, collected[0].level)
+            assertEquals(Level.WARN, collected[1].level)
+            assertEquals(Level.INFO, collected[2].level)
+            assertEquals(Level.DEBUG, collected[3].level)
+            assertEquals(Level.TRACE, collected[4].level)
         }
-        assertEquals(Level.ERROR, collected[0].level)
-        assertEquals(Level.WARN, collected[1].level)
-        assertEquals(Level.INFO, collected[2].level)
-        assertEquals(Level.DEBUG, collected[3].level)
-        assertEquals(Level.TRACE, collected[4].level)
-    }
 
     @Test
-    fun asyncHauler_shipWithMetadata() = runTest {
-        val collected = mutableListOf<Box>()
-        val hauler = Hauler { collected.add(it) }
-        val async = hauler.asAsync(this)
+    fun asyncHauler_shipWithMetadata() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+            val async = hauler.asAsync(this)
 
-        async.ship(Level.INFO, "meta", metadata = mapOf("key" to "val"))
-        withTimeout(2.seconds) {
-            while (collected.isEmpty()) delay(10)
+            async.ship(Level.INFO, "meta", metadata = mapOf("key" to "val"))
+            withTimeout(2.seconds) {
+                while (collected.isEmpty()) delay(10)
+            }
+            assertEquals(mapOf("key" to "val"), collected[0].metadata)
         }
-        assertEquals(mapOf("key" to "val"), collected[0].metadata)
-    }
 
     @Test
-    fun asyncHauler_shipWithThrowable() = runTest {
-        val collected = mutableListOf<Box>()
-        val hauler = Hauler { collected.add(it) }
-        val async = hauler.asAsync(this)
+    fun asyncHauler_shipWithThrowable() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+            val async = hauler.asAsync(this)
 
-        async.ship(Level.ERROR, "oops", RuntimeException("boom"))
-        withTimeout(2.seconds) {
-            while (collected.isEmpty()) delay(10)
+            async.ship(Level.ERROR, "oops", RuntimeException("boom"))
+            withTimeout(2.seconds) {
+                while (collected.isEmpty()) delay(10)
+            }
+            assertTrue(collected[0].message.contains("oops"))
+            assertTrue(collected[0].message.contains("boom"))
         }
-        assertTrue(collected[0].message.contains("oops"))
-        assertTrue(collected[0].message.contains("boom"))
-    }
 }

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/CircularBufferTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/CircularBufferTest.kt
@@ -19,7 +19,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class CircularBufferTest {
-
     @Test
     fun emptyBuffer_returnsEmptyList() {
         val buffer = CircularBuffer<Int>(5)

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/ConversionsTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/ConversionsTest.kt
@@ -23,7 +23,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ConversionsTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",
@@ -43,46 +42,50 @@ class ConversionsTest {
 
     @Test
     fun packUnpack_multipleItems() {
-        val original = listOf(
-            box(level = Level.INFO, loggerName = "A", message = "msg1", timestamp = 100),
-            box(level = Level.WARN, loggerName = "B", message = "msg2", timestamp = 200),
-            box(level = Level.ERROR, loggerName = "A", message = "msg3", timestamp = 300),
-        )
+        val original =
+            listOf(
+                box(level = Level.INFO, loggerName = "A", message = "msg1", timestamp = 100),
+                box(level = Level.WARN, loggerName = "B", message = "msg2", timestamp = 200),
+                box(level = Level.ERROR, loggerName = "A", message = "msg3", timestamp = 300),
+            )
         val unpacked = original.pack().unpack()
         assertEquals(original, unpacked)
     }
 
     @Test
     fun packUnpack_preservesOrder() {
-        val original = (1..20).map { i ->
-            box(
-                loggerName = "logger${i % 5}",
-                message = "msg $i",
-                timestamp = i.toLong(),
-                threadName = "thread-${i % 3}",
-            )
-        }
+        val original =
+            (1..20).map { i ->
+                box(
+                    loggerName = "logger${i % 5}",
+                    message = "msg $i",
+                    timestamp = i.toLong(),
+                    threadName = "thread-${i % 3}",
+                )
+            }
         val unpacked = original.pack().unpack()
         assertEquals(original, unpacked)
     }
 
     @Test
     fun packUnpack_nullThreadName() {
-        val original = listOf(
-            box(threadName = null),
-            box(threadName = "main"),
-            box(threadName = null),
-        )
+        val original =
+            listOf(
+                box(threadName = null),
+                box(threadName = "main"),
+                box(threadName = null),
+            )
         val unpacked = original.pack().unpack()
         assertEquals(original, unpacked)
     }
 
     @Test
     fun packUnpack_allNullThreadNames() {
-        val original = listOf(
-            box(threadName = null),
-            box(threadName = null, message = "msg2"),
-        )
+        val original =
+            listOf(
+                box(threadName = null),
+                box(threadName = null, message = "msg2"),
+            )
         val unpacked = original.pack().unpack()
         assertEquals(original, unpacked)
     }
@@ -99,9 +102,10 @@ class ConversionsTest {
 
     @Test
     fun packUnpack_allLevels() {
-        val original = Level.entries.map { level ->
-            box(level = level, message = "level ${level.name}")
-        }
+        val original =
+            Level.entries.map { level ->
+                box(level = level, message = "level ${level.name}")
+            }
         val unpacked = original.pack().unpack()
         assertEquals(original, unpacked)
     }
@@ -110,36 +114,39 @@ class ConversionsTest {
 
     @Test
     fun pack_deduplicatesLoggerNames() {
-        val original = listOf(
-            box(loggerName = "A"),
-            box(loggerName = "B"),
-            box(loggerName = "A"),
-            box(loggerName = "B"),
-            box(loggerName = "C"),
-        )
+        val original =
+            listOf(
+                box(loggerName = "A"),
+                box(loggerName = "B"),
+                box(loggerName = "A"),
+                box(loggerName = "B"),
+                box(loggerName = "C"),
+            )
         val palette = original.pack()
         assertEquals(listOf("A", "B", "C"), palette.loggerNames)
     }
 
     @Test
     fun pack_deduplicatesThreadNames() {
-        val original = listOf(
-            box(threadName = "t1"),
-            box(threadName = "t2"),
-            box(threadName = "t1"),
-            box(threadName = "t2"),
-        )
+        val original =
+            listOf(
+                box(threadName = "t1"),
+                box(threadName = "t2"),
+                box(threadName = "t1"),
+                box(threadName = "t2"),
+            )
         val palette = original.pack()
         assertEquals(listOf("t1", "t2"), palette.threadNames)
     }
 
     @Test
     fun pack_loggerIndicesAreCorrect() {
-        val original = listOf(
-            box(loggerName = "A"),
-            box(loggerName = "B"),
-            box(loggerName = "A"),
-        )
+        val original =
+            listOf(
+                box(loggerName = "A"),
+                box(loggerName = "B"),
+                box(loggerName = "A"),
+            )
         val palette = original.pack()
         assertEquals(0, palette.messages[0].loggerName) // "A" -> index 0
         assertEquals(1, palette.messages[1].loggerName) // "B" -> index 1
@@ -148,12 +155,13 @@ class ConversionsTest {
 
     @Test
     fun pack_threadIndicesAreCorrect() {
-        val original = listOf(
-            box(threadName = "main"),
-            box(threadName = "worker"),
-            box(threadName = "main"),
-            box(threadName = null),
-        )
+        val original =
+            listOf(
+                box(threadName = "main"),
+                box(threadName = "worker"),
+                box(threadName = "main"),
+                box(threadName = null),
+            )
         val palette = original.pack()
         assertEquals(0, palette.messages[0].threadName) // "main" -> index 0
         assertEquals(1, palette.messages[1].threadName) // "worker" -> index 1
@@ -165,11 +173,12 @@ class ConversionsTest {
 
     @Test
     fun forEach_visitsAllItems() {
-        val original = listOf(
-            box(message = "a"),
-            box(message = "b"),
-            box(message = "c"),
-        )
+        val original =
+            listOf(
+                box(message = "a"),
+                box(message = "b"),
+                box(message = "c"),
+            )
         val palette = original.pack()
         val visited = mutableListOf<Box>()
         palette.forEach { visited.add(it) }
@@ -205,11 +214,12 @@ class ConversionsTest {
 
     @Test
     fun unpack_invalidLoggerIndex_throws() {
-        val palette = Palette(
-            loggerNames = listOf("A"),
-            threadNames = emptyList(),
-            messages = listOf(Package(INFO_INT, 5, "msg", 100L, null)),
-        )
+        val palette =
+            Palette(
+                loggerNames = listOf("A"),
+                threadNames = emptyList(),
+                messages = listOf(Package(INFO_INT, 5, "msg", 100L, null)),
+            )
         assertFailsWith<IllegalArgumentException> {
             palette.unpack()
         }
@@ -217,11 +227,12 @@ class ConversionsTest {
 
     @Test
     fun unpack_invalidThreadIndex_throws() {
-        val palette = Palette(
-            loggerNames = listOf("A"),
-            threadNames = listOf("t1"),
-            messages = listOf(Package(INFO_INT, 0, "msg", 100L, 5)),
-        )
+        val palette =
+            Palette(
+                loggerNames = listOf("A"),
+                threadNames = listOf("t1"),
+                messages = listOf(Package(INFO_INT, 0, "msg", 100L, 5)),
+            )
         assertFailsWith<IllegalArgumentException> {
             palette.unpack()
         }
@@ -231,21 +242,23 @@ class ConversionsTest {
 
     @Test
     fun packUnpack_withMetadata() {
-        val original = listOf(
-            box().copy(metadata = mapOf("key1" to "value1", "key2" to "value2")),
-            box(message = "msg2").copy(metadata = mapOf("requestId" to "abc-123")),
-        )
+        val original =
+            listOf(
+                box().copy(metadata = mapOf("key1" to "value1", "key2" to "value2")),
+                box(message = "msg2").copy(metadata = mapOf("requestId" to "abc-123")),
+            )
         val unpacked = original.pack().unpack()
         assertEquals(original, unpacked)
     }
 
     @Test
     fun packUnpack_mixedMetadata() {
-        val original = listOf(
-            box().copy(metadata = mapOf("key" to "val")),
-            box(message = "msg2"),
-            box(message = "msg3").copy(metadata = null),
-        )
+        val original =
+            listOf(
+                box().copy(metadata = mapOf("key" to "val")),
+                box(message = "msg2"),
+                box(message = "msg3").copy(metadata = null),
+            )
         val unpacked = original.pack().unpack()
         assertEquals(original, unpacked)
     }

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/CustomerPickupImplTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/CustomerPickupImplTest.kt
@@ -24,7 +24,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
 
 class CustomerPickupImplTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",
@@ -34,7 +33,10 @@ class CustomerPickupImplTest {
     ) = Box(level, loggerName, message, timestamp, threadName)
 
     /** Poll get() accumulating results until expected count, yielding to let external scopes run. */
-    private suspend fun pollBoxes(pickup: CustomerPickup, expected: Int): List<Box> {
+    private suspend fun pollBoxes(
+        pickup: CustomerPickup,
+        expected: Int,
+    ): List<Box> {
         val all = mutableListOf<Box>()
         withTimeout(5.seconds) {
             while (all.size < expected) {
@@ -46,126 +48,133 @@ class CustomerPickupImplTest {
     }
 
     @Test
-    fun get_returnsCollectedBoxes() = runTest {
-        val flow = MutableSharedFlow<Box>(replay = 100)
-        val pickup = CustomerPickupImpl(flow, DeliveryRates(onDeliveryError = {}), this)
+    fun get_returnsCollectedBoxes() =
+        runTest {
+            val flow = MutableSharedFlow<Box>(replay = 100)
+            val pickup = CustomerPickupImpl(flow, DeliveryRates(onDeliveryError = {}), this)
 
-        flow.emit(box(message = "a"))
-        flow.emit(box(message = "b"))
+            flow.emit(box(message = "a"))
+            flow.emit(box(message = "b"))
 
-        val boxes = pollBoxes(pickup, 2)
-        assertEquals(2, boxes.size)
-        assertEquals("a", boxes[0].message)
-        assertEquals("b", boxes[1].message)
-        pickup.close()
-    }
-
-    @Test
-    fun get_clearsBufferAfterRead() = runTest {
-        val flow = MutableSharedFlow<Box>(replay = 100)
-        val pickup = CustomerPickupImpl(flow, DeliveryRates(onDeliveryError = {}), this)
-
-        flow.emit(box(message = "first"))
-        val first = pollBoxes(pickup, 1)
-        assertEquals(1, first.size)
-
-        // Buffer was cleared, second get should be empty
-        val palette2 = pickup.get()
-        assertEquals(0, palette2.unpack().size)
-        pickup.close()
-    }
-
-    @Test
-    fun get_respectsCircularBufferSize() = runTest {
-        val rates = DeliveryRates(defaultPaletteSize = 3, onDeliveryError = {})
-        val flow = MutableSharedFlow<Box>(replay = 100)
-        val pickup = CustomerPickupImpl(flow, rates, this)
-
-        for (i in 1..5) {
-            flow.emit(box(message = "msg$i"))
+            val boxes = pollBoxes(pickup, 2)
+            assertEquals(2, boxes.size)
+            assertEquals("a", boxes[0].message)
+            assertEquals("b", boxes[1].message)
+            pickup.close()
         }
 
-        val boxes = pollBoxes(pickup, 3)
-        // CircularBuffer(3) keeps last 3 items
-        assertEquals(3, boxes.size)
-        assertEquals("msg3", boxes[0].message)
-        assertEquals("msg4", boxes[1].message)
-        assertEquals("msg5", boxes[2].message)
-        pickup.close()
-    }
-
     @Test
-    fun get_emptyWhenNothingEmitted() = runTest {
-        val flow = MutableSharedFlow<Box>(replay = 100)
-        val pickup = CustomerPickupImpl(flow, DeliveryRates(onDeliveryError = {}), this)
+    fun get_clearsBufferAfterRead() =
+        runTest {
+            val flow = MutableSharedFlow<Box>(replay = 100)
+            val pickup = CustomerPickupImpl(flow, DeliveryRates(onDeliveryError = {}), this)
 
-        val palette = pickup.get()
-        assertEquals(0, palette.unpack().size)
-        pickup.close()
-    }
+            flow.emit(box(message = "first"))
+            val first = pollBoxes(pickup, 1)
+            assertEquals(1, first.size)
 
-    @Test
-    fun get_multiplePollingCycles() = runTest {
-        val flow = MutableSharedFlow<Box>(replay = 100)
-        val pickup = CustomerPickupImpl(flow, DeliveryRates(onDeliveryError = {}), this)
-
-        flow.tryEmit(box(message = "batch1"))
-        val p1 = pollBoxes(pickup, 1)
-        assertEquals(1, p1.size)
-
-        flow.tryEmit(box(message = "batch2a"))
-        flow.tryEmit(box(message = "batch2b"))
-        val p2 = pollBoxes(pickup, 2)
-        assertEquals(2, p2.size)
-
-        pickup.close()
-    }
-
-    @Test
-    fun get_respectsMaxEntries() = runTest {
-        val flow = MutableSharedFlow<Box>(replay = 100)
-        val pickup = CustomerPickupImpl(flow, DeliveryRates(defaultPaletteSize = 100, onDeliveryError = {}), this)
-
-        for (i in 1..5) {
-            flow.emit(box(message = "msg$i"))
+            // Buffer was cleared, second get should be empty
+            val palette2 = pickup.get()
+            assertEquals(0, palette2.unpack().size)
+            pickup.close()
         }
-        // Wait for all 5 to buffer
-        pollBoxes(pickup, 5).also { assertEquals(5, it.size) }
 
-        // Emit 5 more and wait for them to buffer
-        for (i in 6..10) {
-            flow.emit(box(message = "msg$i"))
-        }
-        // Poll with maxEntries=3 — should return at most 3
-        withTimeout(5.seconds) {
-            while (true) {
-                val batch = pickup.get(maxEntries = 3).unpack()
-                if (batch.isNotEmpty()) {
-                    assertEquals(3, batch.size)
-                    assertEquals("msg6", batch[0].message)
-                    assertEquals("msg7", batch[1].message)
-                    assertEquals("msg8", batch[2].message)
-                    // Remaining 2 should still be available
-                    val rest = pollBoxes(pickup, 2)
-                    assertEquals(2, rest.size)
-                    assertEquals("msg9", rest[0].message)
-                    assertEquals("msg10", rest[1].message)
-                    break
-                }
-                delay(1)
+    @Test
+    fun get_respectsCircularBufferSize() =
+        runTest {
+            val rates = DeliveryRates(defaultPaletteSize = 3, onDeliveryError = {})
+            val flow = MutableSharedFlow<Box>(replay = 100)
+            val pickup = CustomerPickupImpl(flow, rates, this)
+
+            for (i in 1..5) {
+                flow.emit(box(message = "msg$i"))
             }
+
+            val boxes = pollBoxes(pickup, 3)
+            // CircularBuffer(3) keeps last 3 items
+            assertEquals(3, boxes.size)
+            assertEquals("msg3", boxes[0].message)
+            assertEquals("msg4", boxes[1].message)
+            assertEquals("msg5", boxes[2].message)
+            pickup.close()
         }
-        pickup.close()
-    }
 
     @Test
-    fun close_stopsCollection() = runTest {
-        val flow = MutableSharedFlow<Box>(replay = 100)
-        val pickup = CustomerPickupImpl(flow, DeliveryRates(onDeliveryError = {}), this)
+    fun get_emptyWhenNothingEmitted() =
+        runTest {
+            val flow = MutableSharedFlow<Box>(replay = 100)
+            val pickup = CustomerPickupImpl(flow, DeliveryRates(onDeliveryError = {}), this)
 
-        flow.emit(box(message = "before"))
-        pollBoxes(pickup, 1)
-        pickup.close()
-        // Verifies close() doesn't throw
-    }
+            val palette = pickup.get()
+            assertEquals(0, palette.unpack().size)
+            pickup.close()
+        }
+
+    @Test
+    fun get_multiplePollingCycles() =
+        runTest {
+            val flow = MutableSharedFlow<Box>(replay = 100)
+            val pickup = CustomerPickupImpl(flow, DeliveryRates(onDeliveryError = {}), this)
+
+            flow.tryEmit(box(message = "batch1"))
+            val p1 = pollBoxes(pickup, 1)
+            assertEquals(1, p1.size)
+
+            flow.tryEmit(box(message = "batch2a"))
+            flow.tryEmit(box(message = "batch2b"))
+            val p2 = pollBoxes(pickup, 2)
+            assertEquals(2, p2.size)
+
+            pickup.close()
+        }
+
+    @Test
+    fun get_respectsMaxEntries() =
+        runTest {
+            val flow = MutableSharedFlow<Box>(replay = 100)
+            val pickup = CustomerPickupImpl(flow, DeliveryRates(defaultPaletteSize = 100, onDeliveryError = {}), this)
+
+            for (i in 1..5) {
+                flow.emit(box(message = "msg$i"))
+            }
+            // Wait for all 5 to buffer
+            pollBoxes(pickup, 5).also { assertEquals(5, it.size) }
+
+            // Emit 5 more and wait for them to buffer
+            for (i in 6..10) {
+                flow.emit(box(message = "msg$i"))
+            }
+            // Poll with maxEntries=3 — should return at most 3
+            withTimeout(5.seconds) {
+                while (true) {
+                    val batch = pickup.get(maxEntries = 3).unpack()
+                    if (batch.isNotEmpty()) {
+                        assertEquals(3, batch.size)
+                        assertEquals("msg6", batch[0].message)
+                        assertEquals("msg7", batch[1].message)
+                        assertEquals("msg8", batch[2].message)
+                        // Remaining 2 should still be available
+                        val rest = pollBoxes(pickup, 2)
+                        assertEquals(2, rest.size)
+                        assertEquals("msg9", rest[0].message)
+                        assertEquals("msg10", rest[1].message)
+                        break
+                    }
+                    delay(1)
+                }
+            }
+            pickup.close()
+        }
+
+    @Test
+    fun close_stopsCollection() =
+        runTest {
+            val flow = MutableSharedFlow<Box>(replay = 100)
+            val pickup = CustomerPickupImpl(flow, DeliveryRates(onDeliveryError = {}), this)
+
+            flow.emit(box(message = "before"))
+            pollBoxes(pickup, 1)
+            pickup.close()
+            // Verifies close() doesn't throw
+        }
 }

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/DeliveryServiceTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/DeliveryServiceTest.kt
@@ -34,7 +34,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
 
 class DeliveryServiceTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",
@@ -51,7 +50,10 @@ class DeliveryServiceTest {
     }
 
     /** Wait for a condition by polling, yielding to let external scopes run. */
-    private suspend fun awaitCondition(description: String = "", check: () -> Boolean) {
+    private suspend fun awaitCondition(
+        description: String = "",
+        check: () -> Boolean,
+    ) {
         withTimeout(5.seconds) {
             while (!check()) delay(1)
         }
@@ -60,179 +62,194 @@ class DeliveryServiceTest {
     // --- streamDeliveries ---
 
     @Test
-    fun streamDeliveries_receivesEvents() = runTest {
-        withContext(Dispatchers.Default) {
-            val (flow, service, scope) = createDeliveryService()
-            val received = mutableListOf<Box>()
-            val collectJob = launch {
-                service.streamDeliveries().collect { received.add(it) }
-            }
-            delay(50)
+    fun streamDeliveries_receivesEvents() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val (flow, service, scope) = createDeliveryService()
+                val received = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        service.streamDeliveries().collect { received.add(it) }
+                    }
+                delay(50)
 
-            flow.emit(box(message = "a"))
-            flow.emit(box(message = "b"))
-            awaitCondition { received.size >= 2 }
-            assertEquals(2, received.size)
-            assertEquals("a", received[0].message)
-            assertEquals("b", received[1].message)
-            collectJob.cancelAndJoin()
-            scope.cancel()
+                flow.emit(box(message = "a"))
+                flow.emit(box(message = "b"))
+                awaitCondition { received.size >= 2 }
+                assertEquals(2, received.size)
+                assertEquals("a", received[0].message)
+                assertEquals("b", received[1].message)
+                collectJob.cancelAndJoin()
+                scope.cancel()
+            }
         }
-    }
 
     @Test
-    fun streamDeliveries_cancellationStopsDelivery() = runTest {
-        withContext(Dispatchers.Default) {
-            val (flow, service, scope) = createDeliveryService()
-            val received = mutableListOf<Box>()
-            val collectJob = launch {
-                service.streamDeliveries().collect { received.add(it) }
+    fun streamDeliveries_cancellationStopsDelivery() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val (flow, service, scope) = createDeliveryService()
+                val received = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        service.streamDeliveries().collect { received.add(it) }
+                    }
+                delay(50)
+
+                flow.emit(box(message = "before"))
+                awaitCondition { received.size >= 1 }
+                collectJob.cancelAndJoin()
+
+                flow.emit(box(message = "after"))
+                // Brief wait to verify "after" does NOT arrive
+                repeat(50) { delay(1) }
+
+                assertEquals(1, received.size)
+                assertEquals("before", received[0].message)
+                scope.cancel()
             }
-            delay(50)
-
-            flow.emit(box(message = "before"))
-            awaitCondition { received.size >= 1 }
-            collectJob.cancelAndJoin()
-
-            flow.emit(box(message = "after"))
-            // Brief wait to verify "after" does NOT arrive
-            repeat(50) { delay(1) }
-
-            assertEquals(1, received.size)
-            assertEquals("before", received[0].message)
-            scope.cancel()
         }
-    }
 
     // --- streamDeliveriesPacked ---
 
     @Test
-    fun streamDeliveriesPacked_receivesPalettes() = runTest {
-        withContext(Dispatchers.Default) {
-            val rates = DeliveryRates(defaultPaletteSize = 2, defaultPaletteInterval = 100.seconds)
-            val flow = MutableSharedFlow<Box>(replay = 100)
-            val scope = CoroutineScope(SupervisorJob())
-            val service = flow.deliveries(scope, rates)
+    fun streamDeliveriesPacked_receivesPalettes() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val rates = DeliveryRates(defaultPaletteSize = 2, defaultPaletteInterval = 100.seconds)
+                val flow = MutableSharedFlow<Box>(replay = 100)
+                val scope = CoroutineScope(SupervisorJob())
+                val service = flow.deliveries(scope, rates)
 
-            val received = mutableListOf<Palette>()
-            val collectJob = launch {
-                service.streamDeliveriesPacked().collect { received.add(it) }
+                val received = mutableListOf<Palette>()
+                val collectJob =
+                    launch {
+                        service.streamDeliveriesPacked().collect { received.add(it) }
+                    }
+                delay(50)
+
+                flow.emit(box(message = "a"))
+                flow.emit(box(message = "b"))
+                awaitCondition { received.isNotEmpty() }
+                collectJob.cancelAndJoin()
+                scope.cancel()
             }
-            delay(50)
-
-            flow.emit(box(message = "a"))
-            flow.emit(box(message = "b"))
-            awaitCondition { received.isNotEmpty() }
-            collectJob.cancelAndJoin()
-            scope.cancel()
         }
-    }
 
     // --- weighIn (filtering) ---
 
     @Test
-    fun weighIn_filtersEvents() = runTest {
-        withContext(Dispatchers.Default) {
-            val (flow, service, scope) = createDeliveryService()
-            val filtered = service.weighIn(LevelFilter(LevelMatchMode.EQ, Level.ERROR))
+    fun weighIn_filtersEvents() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val (flow, service, scope) = createDeliveryService()
+                val filtered = service.weighIn(LevelFilter(LevelMatchMode.EQ, Level.ERROR))
 
-            val received = mutableListOf<Box>()
-            val collectJob = launch {
-                filtered.streamDeliveries().collect { received.add(it) }
+                val received = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        filtered.streamDeliveries().collect { received.add(it) }
+                    }
+                delay(50)
+
+                flow.emit(box(level = Level.INFO, message = "info"))
+                flow.emit(box(level = Level.ERROR, message = "error"))
+                awaitCondition { received.size >= 1 }
+                assertEquals(1, received.size)
+                assertEquals("error", received[0].message)
+                collectJob.cancelAndJoin()
+                scope.cancel()
             }
-            delay(50)
-
-            flow.emit(box(level = Level.INFO, message = "info"))
-            flow.emit(box(level = Level.ERROR, message = "error"))
-            awaitCondition { received.size >= 1 }
-            assertEquals(1, received.size)
-            assertEquals("error", received[0].message)
-            collectJob.cancelAndJoin()
-            scope.cancel()
         }
-    }
 
     @Test
-    fun weighIn_chainedFilters() = runTest {
-        withContext(Dispatchers.Default) {
-            val (flow, service, scope) = createDeliveryService()
-            val filtered = service
-                .weighIn(LevelFilter(LevelMatchMode.GT, Level.DEBUG))
-                .weighIn(LoggerNameFilter(LoggerMatchMode.PREFIX, "com"))
+    fun weighIn_chainedFilters() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val (flow, service, scope) = createDeliveryService()
+                val filtered =
+                    service
+                        .weighIn(LevelFilter(LevelMatchMode.GT, Level.DEBUG))
+                        .weighIn(LoggerNameFilter(LoggerMatchMode.PREFIX, "com"))
 
-            val received = mutableListOf<Box>()
-            val collectJob = launch {
-                filtered.streamDeliveries().collect { received.add(it) }
+                val received = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        filtered.streamDeliveries().collect { received.add(it) }
+                    }
+                delay(50)
+
+                flow.emit(box(level = Level.INFO, loggerName = "com.example", message = "yes"))
+                flow.emit(box(level = Level.INFO, loggerName = "org.other", message = "no"))
+                flow.emit(box(level = Level.DEBUG, loggerName = "com.example", message = "no2"))
+                awaitCondition { received.size >= 1 }
+                // Brief extra wait to verify no others arrive
+                repeat(50) { delay(1) }
+                assertEquals(1, received.size)
+                assertEquals("yes", received[0].message)
+                collectJob.cancelAndJoin()
+                scope.cancel()
             }
-            delay(50)
-
-            flow.emit(box(level = Level.INFO, loggerName = "com.example", message = "yes"))
-            flow.emit(box(level = Level.INFO, loggerName = "org.other", message = "no"))
-            flow.emit(box(level = Level.DEBUG, loggerName = "com.example", message = "no2"))
-            awaitCondition { received.size >= 1 }
-            // Brief extra wait to verify no others arrive
-            repeat(50) { delay(1) }
-            assertEquals(1, received.size)
-            assertEquals("yes", received[0].message)
-            collectJob.cancelAndJoin()
-            scope.cancel()
         }
-    }
 
     // --- dumpDeliveries ---
 
     @Test
-    fun dumpDeliveries_returnsReplayedEvents() = runTest {
-        val (flow, service, scope) = createDeliveryService()
-        flow.emit(box(message = "replayed1"))
-        flow.emit(box(message = "replayed2"))
+    fun dumpDeliveries_returnsReplayedEvents() =
+        runTest {
+            val (flow, service, scope) = createDeliveryService()
+            flow.emit(box(message = "replayed1"))
+            flow.emit(box(message = "replayed2"))
 
-        val received = service.dumpDeliveries().toList()
-        assertEquals(2, received.size)
-        assertEquals("replayed1", received[0].message)
-        assertEquals("replayed2", received[1].message)
-        scope.cancel()
-    }
+            val received = service.dumpDeliveries().toList()
+            assertEquals(2, received.size)
+            assertEquals("replayed1", received[0].message)
+            assertEquals("replayed2", received[1].message)
+            scope.cancel()
+        }
 
     // --- onDeliveryError (server-side source error hook) ---
 
     @Test
-    fun streamDeliveries_sourceErrorReachesOnDeliveryError() = runTest {
-        val errors = mutableListOf<Throwable>()
-        val rates = DeliveryRates(onDeliveryError = { errors.add(it) })
-        val source = flow {
-            emit(box(message = "ok"))
-            throw RuntimeException("source boom")
+    fun streamDeliveries_sourceErrorReachesOnDeliveryError() =
+        runTest {
+            val errors = mutableListOf<Throwable>()
+            val rates = DeliveryRates(onDeliveryError = { errors.add(it) })
+            val source =
+                flow {
+                    emit(box(message = "ok"))
+                    throw RuntimeException("source boom")
+                }
+            val scope = CoroutineScope(SupervisorJob())
+            val service = deliveries(source, emptyFlow(), scope, rates)
+            val received = service.streamDeliveries().toList()
+            assertEquals(1, received.size)
+            assertEquals("ok", received[0].message)
+            assertEquals(1, errors.size)
+            assertEquals("source boom", errors[0].message)
+            scope.cancel()
         }
-        val scope = CoroutineScope(SupervisorJob())
-        val service = deliveries(source, emptyFlow(), scope, rates)
-        val received = service.streamDeliveries().toList()
-        assertEquals(1, received.size)
-        assertEquals("ok", received[0].message)
-        assertEquals(1, errors.size)
-        assertEquals("source boom", errors[0].message)
-        scope.cancel()
-    }
 
     // --- recurringCustomerPickup ---
 
     @Test
-    fun recurringCustomerPickup_collectsFromFlow() = runTest {
-        val (flow, service, scope) = createDeliveryService()
-        val pickup = service.recurringCustomerPickup()
+    fun recurringCustomerPickup_collectsFromFlow() =
+        runTest {
+            val (flow, service, scope) = createDeliveryService()
+            val pickup = service.recurringCustomerPickup()
 
-        flow.emit(box(message = "poll1"))
-        flow.emit(box(message = "poll2"))
+            flow.emit(box(message = "poll1"))
+            flow.emit(box(message = "poll2"))
 
-        val allBoxes = mutableListOf<Box>()
-        withTimeout(5.seconds) {
-            while (allBoxes.size < 2) {
-                allBoxes.addAll(pickup.get().unpack())
-                if (allBoxes.size < 2) delay(1)
+            val allBoxes = mutableListOf<Box>()
+            withTimeout(5.seconds) {
+                while (allBoxes.size < 2) {
+                    allBoxes.addAll(pickup.get().unpack())
+                    if (allBoxes.size < 2) delay(1)
+                }
             }
+            assertEquals(2, allBoxes.size)
+            pickup.close()
+            scope.cancel()
         }
-        assertEquals(2, allBoxes.size)
-        pickup.close()
-        scope.cancel()
-    }
 }

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/FilterBuilderTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/FilterBuilderTest.kt
@@ -23,7 +23,6 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class FilterBuilderTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",
@@ -34,9 +33,10 @@ class FilterBuilderTest {
 
     @Test
     fun singleFilter_passthrough() {
-        val filter = weighStation {
-            level(LevelMatchMode.EQ, Level.INFO)
-        }
+        val filter =
+            weighStation {
+                level(LevelMatchMode.EQ, Level.INFO)
+            }
         assertIs<LevelFilter>(filter)
         assertTrue(box() in filter)
         assertFalse(box(level = Level.WARN) in filter)
@@ -44,10 +44,11 @@ class FilterBuilderTest {
 
     @Test
     fun multipleFilters_implicitAnd() {
-        val filter = weighStation {
-            level(LevelMatchMode.GT, Level.DEBUG)
-            logger(LoggerMatchMode.PREFIX, "com.example")
-        }
+        val filter =
+            weighStation {
+                level(LevelMatchMode.GT, Level.DEBUG)
+                logger(LoggerMatchMode.PREFIX, "com.example")
+            }
         assertIs<AndFilter>(filter)
         assertTrue(box(level = Level.INFO) in filter)
         assertFalse(box(level = Level.TRACE) in filter)
@@ -56,12 +57,13 @@ class FilterBuilderTest {
 
     @Test
     fun orBlock() {
-        val filter = weighStation {
-            or {
-                logger(LoggerMatchMode.PREFIX, "com.example")
-                message(LoggerMatchMode.REGEX, ".*error.*")
+        val filter =
+            weighStation {
+                or {
+                    logger(LoggerMatchMode.PREFIX, "com.example")
+                    message(LoggerMatchMode.REGEX, ".*error.*")
+                }
             }
-        }
         assertTrue(box() in filter)
         assertTrue(box(loggerName = "org.other", message = "an error occurred") in filter)
         assertFalse(box(loggerName = "org.other", message = "all good") in filter)
@@ -69,11 +71,12 @@ class FilterBuilderTest {
 
     @Test
     fun notBlock() {
-        val filter = weighStation {
-            not {
-                level(LevelMatchMode.EQ, Level.DEBUG)
+        val filter =
+            weighStation {
+                not {
+                    level(LevelMatchMode.EQ, Level.DEBUG)
+                }
             }
-        }
         assertIs<NotFilter>(filter)
         assertTrue(box(level = Level.INFO) in filter)
         assertFalse(box(level = Level.DEBUG) in filter)
@@ -81,13 +84,14 @@ class FilterBuilderTest {
 
     @Test
     fun nestedComposition() {
-        val filter = weighStation {
-            level(LevelMatchMode.GT, Level.INFO)
-            or {
-                logger(LoggerMatchMode.PREFIX, "com.example")
-                message(LoggerMatchMode.REGEX, ".*error.*")
+        val filter =
+            weighStation {
+                level(LevelMatchMode.GT, Level.INFO)
+                or {
+                    logger(LoggerMatchMode.PREFIX, "com.example")
+                    message(LoggerMatchMode.REGEX, ".*error.*")
+                }
             }
-        }
         // WARN + com.example -> true
         assertTrue(box(level = Level.WARN) in filter)
         // ERROR + message matches -> true
@@ -100,12 +104,13 @@ class FilterBuilderTest {
 
     @Test
     fun explicitAndBlock() {
-        val filter = weighStation {
-            and {
-                level(LevelMatchMode.GT, Level.DEBUG)
-                logger(LoggerMatchMode.PREFIX, "com")
+        val filter =
+            weighStation {
+                and {
+                    level(LevelMatchMode.GT, Level.DEBUG)
+                    logger(LoggerMatchMode.PREFIX, "com")
+                }
             }
-        }
         assertTrue(box(level = Level.INFO) in filter)
         assertFalse(box(level = Level.TRACE) in filter)
     }
@@ -119,10 +124,11 @@ class FilterBuilderTest {
 
     @Test
     fun threadAndTimeFilters() {
-        val filter = weighStation {
-            thread(LoggerMatchMode.EXACT, "main")
-            time(LevelMatchMode.GT, 500L)
-        }
+        val filter =
+            weighStation {
+                thread(LoggerMatchMode.EXACT, "main")
+                time(LevelMatchMode.GT, 500L)
+            }
         assertTrue(box() in filter)
         assertFalse(box(threadName = "worker") in filter)
         assertFalse(box(timestamp = 100L) in filter)

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/FilterTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/FilterTest.kt
@@ -20,7 +20,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class FilterTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",
@@ -189,37 +188,41 @@ class FilterTest {
 
     @Test
     fun andFilter_bothTrue() {
-        val filter = AndFilter(
-            LevelFilter(LevelMatchMode.EQ, Level.INFO),
-            LoggerNameFilter(LoggerMatchMode.PREFIX, "com.example"),
-        )
+        val filter =
+            AndFilter(
+                LevelFilter(LevelMatchMode.EQ, Level.INFO),
+                LoggerNameFilter(LoggerMatchMode.PREFIX, "com.example"),
+            )
         assertTrue(box() in filter)
     }
 
     @Test
     fun andFilter_oneFalse() {
-        val filter = AndFilter(
-            LevelFilter(LevelMatchMode.EQ, Level.ERROR),
-            LoggerNameFilter(LoggerMatchMode.PREFIX, "com.example"),
-        )
+        val filter =
+            AndFilter(
+                LevelFilter(LevelMatchMode.EQ, Level.ERROR),
+                LoggerNameFilter(LoggerMatchMode.PREFIX, "com.example"),
+            )
         assertFalse(box() in filter)
     }
 
     @Test
     fun orFilter_oneTrue() {
-        val filter = OrFilter(
-            LevelFilter(LevelMatchMode.EQ, Level.ERROR),
-            LoggerNameFilter(LoggerMatchMode.PREFIX, "com.example"),
-        )
+        val filter =
+            OrFilter(
+                LevelFilter(LevelMatchMode.EQ, Level.ERROR),
+                LoggerNameFilter(LoggerMatchMode.PREFIX, "com.example"),
+            )
         assertTrue(box() in filter)
     }
 
     @Test
     fun orFilter_bothFalse() {
-        val filter = OrFilter(
-            LevelFilter(LevelMatchMode.EQ, Level.ERROR),
-            LoggerNameFilter(LoggerMatchMode.EXACT, "org.other"),
-        )
+        val filter =
+            OrFilter(
+                LevelFilter(LevelMatchMode.EQ, Level.ERROR),
+                LoggerNameFilter(LoggerMatchMode.EXACT, "org.other"),
+            )
         assertFalse(box() in filter)
     }
 
@@ -245,13 +248,14 @@ class FilterTest {
     @Test
     fun deepComposition() {
         // (level > INFO by severity) AND (logger starts with "com" OR message matches ".*error.*")
-        val filter = AndFilter(
-            LevelFilter(LevelMatchMode.GT, Level.INFO),
-            OrFilter(
-                LoggerNameFilter(LoggerMatchMode.PREFIX, "com"),
-                MessageFilter(LoggerMatchMode.REGEX, ".*error.*"),
-            ),
-        )
+        val filter =
+            AndFilter(
+                LevelFilter(LevelMatchMode.GT, Level.INFO),
+                OrFilter(
+                    LoggerNameFilter(LoggerMatchMode.PREFIX, "com"),
+                    MessageFilter(LoggerMatchMode.REGEX, ".*error.*"),
+                ),
+            )
         assertTrue(box(level = Level.WARN) in filter)
         assertFalse(box(level = Level.DEBUG) in filter)
         assertTrue(box(level = Level.ERROR, loggerName = "org.other", message = "an error occurred") in filter)

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/FlowsTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/FlowsTest.kt
@@ -36,7 +36,6 @@ import kotlin.time.Duration.Companion.seconds
  * DeliveryServiceTest / PipelineIntegrationTest.
  */
 class FlowsTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",
@@ -46,63 +45,69 @@ class FlowsTest {
     ) = Box(level, loggerName, message, timestamp, threadName)
 
     @Test
-    fun withPickup_receivesLiveEvents() = runTest {
-        withContext(Dispatchers.Default) {
-            val warehouse = Warehouse(DeliveryRates())
-            val dropBox = warehouse.requestPickup()
-            val service = warehouse.deliveries()
-            val scope = CoroutineScope(SupervisorJob())
+    fun withPickup_receivesLiveEvents() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates())
+                val dropBox = warehouse.requestPickup()
+                val service = warehouse.deliveries()
+                val scope = CoroutineScope(SupervisorJob())
 
-            val result = mutableListOf<Box>()
-            val collectJob = launch {
-                service.withPickup(interval = 50.milliseconds, closeScope = scope)
-                    .collect { result.add(it) }
+                val result = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        service
+                            .withPickup(interval = 50.milliseconds, closeScope = scope)
+                            .collect { result.add(it) }
+                    }
+                delay(200)
+
+                dropBox.log(box(message = "a"))
+                dropBox.log(box(message = "b"))
+
+                withTimeout(5.seconds) {
+                    while (result.size < 2) delay(50)
+                }
+                assertEquals(2, result.size)
+                assertEquals("a", result[0].message)
+                assertEquals("b", result[1].message)
+
+                collectJob.cancelAndJoin()
+                scope.cancel()
+                warehouse.close()
             }
-            delay(200)
-
-            dropBox.log(box(message = "a"))
-            dropBox.log(box(message = "b"))
-
-            withTimeout(5.seconds) {
-                while (result.size < 2) delay(50)
-            }
-            assertEquals(2, result.size)
-            assertEquals("a", result[0].message)
-            assertEquals("b", result[1].message)
-
-            collectJob.cancelAndJoin()
-            scope.cancel()
-            warehouse.close()
         }
-    }
 
     @Test
-    fun dumpWithPickup_returnsReplayedBoxes() = runTest {
-        withContext(Dispatchers.Default) {
-            val warehouse = Warehouse(DeliveryRates(defaultBoxRetention = 100))
-            val dropBox = warehouse.requestPickup()
-            dropBox.log(box(message = "r1"))
-            dropBox.log(box(message = "r2"))
+    fun dumpWithPickup_returnsReplayedBoxes() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates(defaultBoxRetention = 100))
+                val dropBox = warehouse.requestPickup()
+                dropBox.log(box(message = "r1"))
+                dropBox.log(box(message = "r2"))
 
-            val service = warehouse.deliveries()
-            val scope = CoroutineScope(SupervisorJob())
+                val service = warehouse.deliveries()
+                val scope = CoroutineScope(SupervisorJob())
 
-            val result = mutableListOf<Box>()
-            val collectJob = launch {
-                service.dumpWithPickup(interval = 50.milliseconds, closeScope = scope)
-                    .collect { result.add(it) }
+                val result = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        service
+                            .dumpWithPickup(interval = 50.milliseconds, closeScope = scope)
+                            .collect { result.add(it) }
+                    }
+
+                withTimeout(5.seconds) {
+                    while (result.size < 2) delay(50)
+                }
+                assertEquals(2, result.size)
+                assertEquals("r1", result[0].message)
+                assertEquals("r2", result[1].message)
+
+                collectJob.cancelAndJoin()
+                scope.cancel()
+                warehouse.close()
             }
-
-            withTimeout(5.seconds) {
-                while (result.size < 2) delay(50)
-            }
-            assertEquals(2, result.size)
-            assertEquals("r1", result[0].message)
-            assertEquals("r2", result[1].message)
-
-            collectJob.cancelAndJoin()
-            scope.cancel()
-            warehouse.close()
         }
-    }
 }

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/GarageTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/GarageTest.kt
@@ -26,7 +26,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
 
 class GarageTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",
@@ -38,126 +37,144 @@ class GarageTest {
     // --- Hauler.named ---
 
     @Test
-    fun named_setsLoggerName() = runTest {
-        val collected = mutableListOf<Box>()
-        val hauler = Hauler { collected.add(it) }
-        val named = hauler.named("MyLogger")
+    fun named_setsLoggerName() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+            val named = hauler.named("MyLogger")
 
-        named.emit(box(loggerName = "original"))
-        assertEquals(1, collected.size)
-        assertEquals("MyLogger", collected[0].loggerName)
-    }
-
-    @Test
-    fun named_preservesOtherFields() = runTest {
-        val collected = mutableListOf<Box>()
-        val hauler = Hauler { collected.add(it) }
-        val named = hauler.named("MyLogger")
-
-        val original = box(level = Level.ERROR, message = "hello", timestamp = 42L)
-        named.emit(original)
-        assertEquals(Level.ERROR, collected[0].level)
-        assertEquals("hello", collected[0].message)
-        assertEquals(42L, collected[0].timestamp)
-    }
+            named.emit(box(loggerName = "original"))
+            assertEquals(1, collected.size)
+            assertEquals("MyLogger", collected[0].loggerName)
+        }
 
     @Test
-    fun named_chainedInnerWins() = runTest {
-        // When chaining named("First").named("Second"), the outer wrapper sets "Second"
-        // then the inner wrapper overwrites with "First", so "First" arrives at the base.
-        val collected = mutableListOf<Box>()
-        val hauler = Hauler { collected.add(it) }
-        val named = hauler.named("First").named("Second")
+    fun named_preservesOtherFields() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+            val named = hauler.named("MyLogger")
 
-        named.emit(box())
-        assertEquals("First", collected[0].loggerName)
-    }
+            val original = box(level = Level.ERROR, message = "hello", timestamp = 42L)
+            named.emit(original)
+            assertEquals(Level.ERROR, collected[0].level)
+            assertEquals("hello", collected[0].message)
+            assertEquals(42L, collected[0].timestamp)
+        }
+
+    @Test
+    fun named_chainedInnerWins() =
+        runTest {
+            // When chaining named("First").named("Second"), the outer wrapper sets "Second"
+            // then the inner wrapper overwrites with "First", so "First" arrives at the base.
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+            val named = hauler.named("First").named("Second")
+
+            named.emit(box())
+            assertEquals("First", collected[0].loggerName)
+        }
 
     // --- Hauler.level ---
 
     @Test
-    fun level_filtersLowSeverity() = runTest {
-        val collected = mutableListOf<Box>()
-        val hauler = Hauler { collected.add(it) }
-        val filtered = hauler.level(Level.WARN)
+    fun level_filtersLowSeverity() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+            val filtered = hauler.level(Level.WARN)
 
-        filtered.emit(box(level = Level.DEBUG))
-        filtered.emit(box(level = Level.INFO))
-        filtered.emit(box(level = Level.WARN))
-        filtered.emit(box(level = Level.ERROR))
+            filtered.emit(box(level = Level.DEBUG))
+            filtered.emit(box(level = Level.INFO))
+            filtered.emit(box(level = Level.WARN))
+            filtered.emit(box(level = Level.ERROR))
 
-        assertEquals(2, collected.size)
-        assertEquals(Level.WARN, collected[0].level)
-        assertEquals(Level.ERROR, collected[1].level)
-    }
-
-    @Test
-    fun level_allowsEqualLevel() = runTest {
-        val collected = mutableListOf<Box>()
-        val hauler = Hauler { collected.add(it) }
-        val filtered = hauler.level(Level.INFO)
-
-        filtered.emit(box(level = Level.INFO))
-        assertEquals(1, collected.size)
-    }
+            assertEquals(2, collected.size)
+            assertEquals(Level.WARN, collected[0].level)
+            assertEquals(Level.ERROR, collected[1].level)
+        }
 
     @Test
-    fun level_allowsHigherSeverity() = runTest {
-        val collected = mutableListOf<Box>()
-        val hauler = Hauler { collected.add(it) }
-        val filtered = hauler.level(Level.DEBUG)
+    fun level_allowsEqualLevel() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+            val filtered = hauler.level(Level.INFO)
 
-        filtered.emit(box(level = Level.ERROR))
-        assertEquals(1, collected.size)
-    }
+            filtered.emit(box(level = Level.INFO))
+            assertEquals(1, collected.size)
+        }
 
     @Test
-    fun level_blocksLowerSeverity() = runTest {
-        val collected = mutableListOf<Box>()
-        val hauler = Hauler { collected.add(it) }
-        val filtered = hauler.level(Level.ERROR)
+    fun level_allowsHigherSeverity() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+            val filtered = hauler.level(Level.DEBUG)
 
-        filtered.emit(box(level = Level.WARN))
-        assertEquals(0, collected.size)
-    }
+            filtered.emit(box(level = Level.ERROR))
+            assertEquals(1, collected.size)
+        }
+
+    @Test
+    fun level_blocksLowerSeverity() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+            val filtered = hauler.level(Level.ERROR)
+
+            filtered.emit(box(level = Level.WARN))
+            assertEquals(0, collected.size)
+        }
 
     // --- hauler() factory ---
 
     @Test
-    fun haulerFactory_setsName() = runTest {
-        val collected = mutableListOf<Box>()
-        val base = Hauler { collected.add(it) }
-        val named = base.named("TestClass")
-        named.emit(box())
-        assertEquals("TestClass", collected[0].loggerName)
-    }
+    fun haulerFactory_setsName() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val base = Hauler { collected.add(it) }
+            val named = base.named("TestClass")
+            named.emit(box())
+            assertEquals("TestClass", collected[0].loggerName)
+        }
 
     // --- Garage global routing ---
 
     @Test
-    fun garage_rootHaulerRoutesToDeliveries() = runTest {
-        val result = mutableListOf<Box>()
-        val job = launch {
-            Garage.deliveries.take(1).toList().let { result.addAll(it) }
+    fun garage_rootHaulerRoutesToDeliveries() =
+        runTest {
+            val result = mutableListOf<Box>()
+            val job =
+                launch {
+                    Garage.deliveries
+                        .take(1)
+                        .toList()
+                        .let { result.addAll(it) }
+                }
+            delay(50)
+            Garage.rootHauler.emit(box(message = "garage test"))
+            withTimeout(2.seconds) { job.join() }
+            assertEquals(1, result.size)
+            assertEquals("garage test", result[0].message)
         }
-        delay(50)
-        Garage.rootHauler.emit(box(message = "garage test"))
-        withTimeout(2.seconds) { job.join() }
-        assertEquals(1, result.size)
-        assertEquals("garage test", result[0].message)
-    }
 
     @Test
-    fun garage_namedHaulerSetsLoggerName() = runTest {
-        val result = mutableListOf<Box>()
-        val job = launch {
-            Garage.deliveries.take(1).toList().let { result.addAll(it) }
-        }
-        delay(50)
+    fun garage_namedHaulerSetsLoggerName() =
+        runTest {
+            val result = mutableListOf<Box>()
+            val job =
+                launch {
+                    Garage.deliveries
+                        .take(1)
+                        .toList()
+                        .let { result.addAll(it) }
+                }
+            delay(50)
 
-        val namedHauler = Garage.rootHauler.named("MyComponent")
-        namedHauler.emit(box())
-        withTimeout(2.seconds) { job.join() }
-        assertEquals("MyComponent", result[0].loggerName)
-    }
+            val namedHauler = Garage.rootHauler.named("MyComponent")
+            namedHauler.emit(box())
+            withTimeout(2.seconds) { job.join() }
+            assertEquals("MyComponent", result[0].loggerName)
+        }
 }

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/HaulerTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/HaulerTest.kt
@@ -21,7 +21,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class HaulerTest {
-
     private fun collectingHauler(): Pair<Hauler, MutableList<Box>> {
         val collected = mutableListOf<Box>()
         val hauler = Hauler { collected.add(it) }
@@ -29,107 +28,119 @@ class HaulerTest {
     }
 
     @Test
-    fun ship_emitsBoxWithCorrectLevel() = runTest {
-        val (hauler, collected) = collectingHauler()
-        hauler.ship(Level.WARN, "test message")
-        assertEquals(1, collected.size)
-        assertEquals(Level.WARN, collected[0].level)
-        assertEquals("test message", collected[0].message)
-    }
-
-    @Test
-    fun ship_includesThrowableInMessage() = runTest {
-        val (hauler, collected) = collectingHauler()
-        val ex = RuntimeException("boom")
-        hauler.ship(Level.ERROR, "failed", ex)
-        assertEquals(1, collected.size)
-        assertTrue(collected[0].message.startsWith("failed\n"))
-        assertTrue(collected[0].message.contains("RuntimeException"))
-        assertTrue(collected[0].message.contains("boom"))
-    }
-
-    @Test
-    fun ship_includesMetadata() = runTest {
-        val (hauler, collected) = collectingHauler()
-        hauler.ship(Level.INFO, "msg", metadata = mapOf("k" to "v"))
-        assertEquals(mapOf("k" to "v"), collected[0].metadata)
-    }
-
-    @Test
-    fun error_usesErrorLevel() = runTest {
-        val (hauler, collected) = collectingHauler()
-        hauler.error("err msg")
-        assertEquals(Level.ERROR, collected[0].level)
-        assertEquals("err msg", collected[0].message)
-    }
-
-    @Test
-    fun warn_usesWarnLevel() = runTest {
-        val (hauler, collected) = collectingHauler()
-        hauler.warn("warn msg")
-        assertEquals(Level.WARN, collected[0].level)
-    }
-
-    @Test
-    fun info_usesInfoLevel() = runTest {
-        val (hauler, collected) = collectingHauler()
-        hauler.info("info msg")
-        assertEquals(Level.INFO, collected[0].level)
-    }
-
-    @Test
-    fun debug_usesDebugLevel() = runTest {
-        val (hauler, collected) = collectingHauler()
-        hauler.debug("debug msg")
-        assertEquals(Level.DEBUG, collected[0].level)
-    }
-
-    @Test
-    fun trace_usesTraceLevel() = runTest {
-        val (hauler, collected) = collectingHauler()
-        hauler.trace("trace msg")
-        assertEquals(Level.TRACE, collected[0].level)
-    }
-
-    @Test
-    fun levelShortcuts_passMetadataThrough() = runTest {
-        val (hauler, collected) = collectingHauler()
-        val meta = mapOf("req" to "123")
-        hauler.error("e", metadata = meta)
-        hauler.warn("w", metadata = meta)
-        hauler.info("i", metadata = meta)
-        hauler.debug("d", metadata = meta)
-        hauler.trace("t", metadata = meta)
-        assertEquals(5, collected.size)
-        collected.forEach { assertEquals(meta, it.metadata) }
-    }
-
-    @Test
-    fun levelShortcuts_passThrowableThrough() = runTest {
-        val (hauler, collected) = collectingHauler()
-        val ex = IllegalStateException("bad")
-        hauler.error("e", ex)
-        hauler.warn("w", ex)
-        hauler.info("i", ex)
-        hauler.debug("d", ex)
-        hauler.trace("t", ex)
-        assertEquals(5, collected.size)
-        collected.forEach {
-            assertTrue(it.message.contains("IllegalStateException"))
+    fun ship_emitsBoxWithCorrectLevel() =
+        runTest {
+            val (hauler, collected) = collectingHauler()
+            hauler.ship(Level.WARN, "test message")
+            assertEquals(1, collected.size)
+            assertEquals(Level.WARN, collected[0].level)
+            assertEquals("test message", collected[0].message)
         }
-    }
 
     @Test
-    fun ship_setsLoggerNameToHauler() = runTest {
-        val (hauler, collected) = collectingHauler()
-        hauler.ship(Level.INFO, "test")
-        assertEquals("Hauler", collected[0].loggerName)
-    }
+    fun ship_includesThrowableInMessage() =
+        runTest {
+            val (hauler, collected) = collectingHauler()
+            val ex = RuntimeException("boom")
+            hauler.ship(Level.ERROR, "failed", ex)
+            assertEquals(1, collected.size)
+            assertTrue(collected[0].message.startsWith("failed\n"))
+            assertTrue(collected[0].message.contains("RuntimeException"))
+            assertTrue(collected[0].message.contains("boom"))
+        }
 
     @Test
-    fun ship_setsTimestamp() = runTest {
-        val (hauler, collected) = collectingHauler()
-        hauler.ship(Level.INFO, "test")
-        assertTrue(collected[0].timestamp > 0)
-    }
+    fun ship_includesMetadata() =
+        runTest {
+            val (hauler, collected) = collectingHauler()
+            hauler.ship(Level.INFO, "msg", metadata = mapOf("k" to "v"))
+            assertEquals(mapOf("k" to "v"), collected[0].metadata)
+        }
+
+    @Test
+    fun error_usesErrorLevel() =
+        runTest {
+            val (hauler, collected) = collectingHauler()
+            hauler.error("err msg")
+            assertEquals(Level.ERROR, collected[0].level)
+            assertEquals("err msg", collected[0].message)
+        }
+
+    @Test
+    fun warn_usesWarnLevel() =
+        runTest {
+            val (hauler, collected) = collectingHauler()
+            hauler.warn("warn msg")
+            assertEquals(Level.WARN, collected[0].level)
+        }
+
+    @Test
+    fun info_usesInfoLevel() =
+        runTest {
+            val (hauler, collected) = collectingHauler()
+            hauler.info("info msg")
+            assertEquals(Level.INFO, collected[0].level)
+        }
+
+    @Test
+    fun debug_usesDebugLevel() =
+        runTest {
+            val (hauler, collected) = collectingHauler()
+            hauler.debug("debug msg")
+            assertEquals(Level.DEBUG, collected[0].level)
+        }
+
+    @Test
+    fun trace_usesTraceLevel() =
+        runTest {
+            val (hauler, collected) = collectingHauler()
+            hauler.trace("trace msg")
+            assertEquals(Level.TRACE, collected[0].level)
+        }
+
+    @Test
+    fun levelShortcuts_passMetadataThrough() =
+        runTest {
+            val (hauler, collected) = collectingHauler()
+            val meta = mapOf("req" to "123")
+            hauler.error("e", metadata = meta)
+            hauler.warn("w", metadata = meta)
+            hauler.info("i", metadata = meta)
+            hauler.debug("d", metadata = meta)
+            hauler.trace("t", metadata = meta)
+            assertEquals(5, collected.size)
+            collected.forEach { assertEquals(meta, it.metadata) }
+        }
+
+    @Test
+    fun levelShortcuts_passThrowableThrough() =
+        runTest {
+            val (hauler, collected) = collectingHauler()
+            val ex = IllegalStateException("bad")
+            hauler.error("e", ex)
+            hauler.warn("w", ex)
+            hauler.info("i", ex)
+            hauler.debug("d", ex)
+            hauler.trace("t", ex)
+            assertEquals(5, collected.size)
+            collected.forEach {
+                assertTrue(it.message.contains("IllegalStateException"))
+            }
+        }
+
+    @Test
+    fun ship_setsLoggerNameToHauler() =
+        runTest {
+            val (hauler, collected) = collectingHauler()
+            hauler.ship(Level.INFO, "test")
+            assertEquals("Hauler", collected[0].loggerName)
+        }
+
+    @Test
+    fun ship_setsTimestamp() =
+        runTest {
+            val (hauler, collected) = collectingHauler()
+            hauler.ship(Level.INFO, "test")
+            assertTrue(collected[0].timestamp > 0)
+        }
 }

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/LogPackerTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/LogPackerTest.kt
@@ -19,7 +19,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class LogPackerTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/PickupsTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/PickupsTest.kt
@@ -28,7 +28,6 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
 class PickupsTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",
@@ -46,95 +45,103 @@ class PickupsTest {
     // --- Deliveries.forwardTo(DropBox) ---
 
     @Test
-    fun forwardToDropBox_forwardsEachBox() = runTest {
-        val flow = MutableSharedFlow<Box>(replay = 100)
-        val scope = CoroutineScope(SupervisorJob())
-        val received = mutableListOf<Box>()
-        val dropBox = object : DropBox {
-            override suspend fun log(logEvent: Box) {
-                received.add(logEvent)
-            }
+    fun forwardToDropBox_forwardsEachBox() =
+        runTest {
+            val flow = MutableSharedFlow<Box>(replay = 100)
+            val scope = CoroutineScope(SupervisorJob())
+            val received = mutableListOf<Box>()
+            val dropBox =
+                object : DropBox {
+                    override suspend fun log(logEvent: Box) {
+                        received.add(logEvent)
+                    }
+                }
+
+            val job = flow.forwardTo(dropBox, scope)
+            assertTrue(job.isActive)
+
+            flow.emit(box(message = "a"))
+            flow.emit(box(message = "b"))
+            awaitCondition { received.size >= 2 }
+
+            assertEquals(2, received.size)
+            assertEquals("a", received[0].message)
+            assertEquals("b", received[1].message)
+            job.cancel()
+            scope.cancel()
         }
-
-        val job = flow.forwardTo(dropBox, scope)
-        assertTrue(job.isActive)
-
-        flow.emit(box(message = "a"))
-        flow.emit(box(message = "b"))
-        awaitCondition { received.size >= 2 }
-
-        assertEquals(2, received.size)
-        assertEquals("a", received[0].message)
-        assertEquals("b", received[1].message)
-        job.cancel()
-        scope.cancel()
-    }
 
     @Test
-    fun forwardToDropBox_jobIsActiveAfterLaunch() = runTest {
-        val flow = MutableSharedFlow<Box>(replay = 100)
-        val scope = CoroutineScope(SupervisorJob())
-        val dropBox = object : DropBox {
-            override suspend fun log(logEvent: Box) {}
+    fun forwardToDropBox_jobIsActiveAfterLaunch() =
+        runTest {
+            val flow = MutableSharedFlow<Box>(replay = 100)
+            val scope = CoroutineScope(SupervisorJob())
+            val dropBox =
+                object : DropBox {
+                    override suspend fun log(logEvent: Box) {}
+                }
+            val job = flow.forwardTo(dropBox, scope)
+            assertTrue(job.isActive)
+            job.cancel()
+            scope.cancel()
         }
-        val job = flow.forwardTo(dropBox, scope)
-        assertTrue(job.isActive)
-        job.cancel()
-        scope.cancel()
-    }
 
     // --- Deliveries.forwardTo(LoadingDock) ---
 
     @Test
-    fun forwardToLoadingDock_forwardsPalettes() = runTest {
-        val flow = MutableSharedFlow<Box>(replay = 100)
-        val scope = CoroutineScope(SupervisorJob())
-        val received = mutableListOf<Palette>()
-        val dock = object : LoadingDock {
-            override suspend fun bulkLog(logs: Palette) {
-                received.add(logs)
-            }
+    fun forwardToLoadingDock_forwardsPalettes() =
+        runTest {
+            val flow = MutableSharedFlow<Box>(replay = 100)
+            val scope = CoroutineScope(SupervisorJob())
+            val received = mutableListOf<Palette>()
+            val dock =
+                object : LoadingDock {
+                    override suspend fun bulkLog(logs: Palette) {
+                        received.add(logs)
+                    }
+                }
+
+            // Small palette size so size-based flush triggers. Long interval to avoid timer-based.
+            val rates = DeliveryRates(defaultPaletteSize = 2, defaultPaletteInterval = 100.seconds, onDeliveryError = {})
+            val job = flow.forwardTo(dock, scope, rates)
+            assertTrue(job.isActive)
+
+            flow.emit(box(message = "x"))
+            flow.emit(box(message = "y"))
+            awaitCondition { received.isNotEmpty() }
+
+            val allBoxes = received.flatMap { it.unpack() }
+            assertTrue(allBoxes.any { it.message == "x" })
+            assertTrue(allBoxes.any { it.message == "y" })
+            job.cancel()
+            scope.cancel()
         }
-
-        // Small palette size so size-based flush triggers. Long interval to avoid timer-based.
-        val rates = DeliveryRates(defaultPaletteSize = 2, defaultPaletteInterval = 100.seconds, onDeliveryError = {})
-        val job = flow.forwardTo(dock, scope, rates)
-        assertTrue(job.isActive)
-
-        flow.emit(box(message = "x"))
-        flow.emit(box(message = "y"))
-        awaitCondition { received.isNotEmpty() }
-
-        val allBoxes = received.flatMap { it.unpack() }
-        assertTrue(allBoxes.any { it.message == "x" })
-        assertTrue(allBoxes.any { it.message == "y" })
-        job.cancel()
-        scope.cancel()
-    }
 
     @Test
-    fun forwardToLoadingDock_respectsPaletteSize() = runTest {
-        val flow = MutableSharedFlow<Box>(replay = 100)
-        val scope = CoroutineScope(SupervisorJob())
-        val received = mutableListOf<Palette>()
-        val dock = object : LoadingDock {
-            override suspend fun bulkLog(logs: Palette) {
-                received.add(logs)
-            }
+    fun forwardToLoadingDock_respectsPaletteSize() =
+        runTest {
+            val flow = MutableSharedFlow<Box>(replay = 100)
+            val scope = CoroutineScope(SupervisorJob())
+            val received = mutableListOf<Palette>()
+            val dock =
+                object : LoadingDock {
+                    override suspend fun bulkLog(logs: Palette) {
+                        received.add(logs)
+                    }
+                }
+
+            // Palette size = 3, long interval so only size triggers flush
+            val rates = DeliveryRates(defaultPaletteSize = 3, defaultPaletteInterval = 100.seconds, onDeliveryError = {})
+            val job = flow.forwardTo(dock, scope, rates)
+
+            flow.emit(box(message = "1"))
+            flow.emit(box(message = "2"))
+            flow.emit(box(message = "3"))
+            awaitCondition { received.isNotEmpty() }
+
+            val allBoxes = received.flatMap { it.unpack() }
+            assertEquals(3, allBoxes.size)
+            job.cancel()
+            scope.cancel()
         }
-
-        // Palette size = 3, long interval so only size triggers flush
-        val rates = DeliveryRates(defaultPaletteSize = 3, defaultPaletteInterval = 100.seconds, onDeliveryError = {})
-        val job = flow.forwardTo(dock, scope, rates)
-
-        flow.emit(box(message = "1"))
-        flow.emit(box(message = "2"))
-        flow.emit(box(message = "3"))
-        awaitCondition { received.isNotEmpty() }
-
-        val allBoxes = received.flatMap { it.unpack() }
-        assertEquals(3, allBoxes.size)
-        job.cancel()
-        scope.cancel()
-    }
 }

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/PipelineIntegrationTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/PipelineIntegrationTest.kt
@@ -33,7 +33,6 @@ import kotlin.time.Duration.Companion.seconds
  * DropBox/LoadingDock -> Warehouse -> DeliveryService -> consumer
  */
 class PipelineIntegrationTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",
@@ -42,230 +41,249 @@ class PipelineIntegrationTest {
         threadName: String? = "main",
     ) = Box(level, loggerName, message, timestamp, threadName)
 
-    private suspend fun awaitCondition(description: String = "", check: () -> Boolean) {
+    private suspend fun awaitCondition(
+        description: String = "",
+        check: () -> Boolean,
+    ) {
         withTimeout(5.seconds) {
             while (!check()) delay(1)
         }
     }
 
     @Test
-    fun dropBox_to_streamDeliveries() = runTest {
-        withContext(Dispatchers.Default) {
-            val warehouse = Warehouse(DeliveryRates())
-            val dropBox = warehouse.requestPickup()
-            val service = warehouse.deliveries()
+    fun dropBox_to_streamDeliveries() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates())
+                val dropBox = warehouse.requestPickup()
+                val service = warehouse.deliveries()
 
-            val received = mutableListOf<Box>()
-            val collectJob = launch {
-                service.streamDeliveries().collect { received.add(it) }
+                val received = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        service.streamDeliveries().collect { received.add(it) }
+                    }
+                delay(50)
+
+                dropBox.log(box(level = Level.INFO, message = "first"))
+                dropBox.log(box(level = Level.WARN, message = "second"))
+                dropBox.log(box(level = Level.ERROR, message = "third"))
+
+                awaitCondition { received.size >= 3 }
+
+                assertEquals(3, received.size)
+                assertEquals(Level.INFO, received[0].level)
+                assertEquals("first", received[0].message)
+                assertEquals(Level.WARN, received[1].level)
+                assertEquals("second", received[1].message)
+                assertEquals(Level.ERROR, received[2].level)
+                assertEquals("third", received[2].message)
+                collectJob.cancelAndJoin()
+                warehouse.close()
             }
-            delay(50)
-
-            dropBox.log(box(level = Level.INFO, message = "first"))
-            dropBox.log(box(level = Level.WARN, message = "second"))
-            dropBox.log(box(level = Level.ERROR, message = "third"))
-
-            awaitCondition { received.size >= 3 }
-
-            assertEquals(3, received.size)
-            assertEquals(Level.INFO, received[0].level)
-            assertEquals("first", received[0].message)
-            assertEquals(Level.WARN, received[1].level)
-            assertEquals("second", received[1].message)
-            assertEquals(Level.ERROR, received[2].level)
-            assertEquals("third", received[2].message)
-            collectJob.cancelAndJoin()
-            warehouse.close()
         }
-    }
 
     @Test
-    fun loadingDock_to_streamDeliveries() = runTest {
-        withContext(Dispatchers.Default) {
-            val warehouse = Warehouse(DeliveryRates())
-            val dock = warehouse.requestDockPickup()
-            val service = warehouse.deliveries()
+    fun loadingDock_to_streamDeliveries() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates())
+                val dock = warehouse.requestDockPickup()
+                val service = warehouse.deliveries()
 
-            val received = mutableListOf<Box>()
-            val collectJob = launch {
-                service.streamDeliveries().collect { received.add(it) }
+                val received = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        service.streamDeliveries().collect { received.add(it) }
+                    }
+                delay(50)
+
+                val boxes =
+                    listOf(
+                        box(message = "bulk1"),
+                        box(message = "bulk2"),
+                        box(message = "bulk3"),
+                    )
+                dock.bulkLog(boxes.pack())
+
+                awaitCondition { received.size >= 3 }
+
+                assertEquals(3, received.size)
+                assertEquals("bulk1", received[0].message)
+                assertEquals("bulk2", received[1].message)
+                assertEquals("bulk3", received[2].message)
+                collectJob.cancelAndJoin()
+                warehouse.close()
             }
-            delay(50)
-
-            val boxes = listOf(
-                box(message = "bulk1"),
-                box(message = "bulk2"),
-                box(message = "bulk3"),
-            )
-            dock.bulkLog(boxes.pack())
-
-            awaitCondition { received.size >= 3 }
-
-            assertEquals(3, received.size)
-            assertEquals("bulk1", received[0].message)
-            assertEquals("bulk2", received[1].message)
-            assertEquals("bulk3", received[2].message)
-            collectJob.cancelAndJoin()
-            warehouse.close()
         }
-    }
 
     @Test
-    fun multipleSources_mergeIntoSingleDelivery() = runTest {
-        withContext(Dispatchers.Default) {
-            val warehouse = Warehouse(DeliveryRates())
-            val drop1 = warehouse.requestPickup()
-            val drop2 = warehouse.requestPickup()
-            val dock = warehouse.requestDockPickup()
-            val service = warehouse.deliveries()
+    fun multipleSources_mergeIntoSingleDelivery() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates())
+                val drop1 = warehouse.requestPickup()
+                val drop2 = warehouse.requestPickup()
+                val dock = warehouse.requestDockPickup()
+                val service = warehouse.deliveries()
 
-            val received = mutableListOf<Box>()
-            val collectJob = launch {
-                service.streamDeliveries().collect { received.add(it) }
+                val received = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        service.streamDeliveries().collect { received.add(it) }
+                    }
+                delay(50)
+
+                drop1.log(box(loggerName = "Source1", message = "from-drop1"))
+                drop2.log(box(loggerName = "Source2", message = "from-drop2"))
+                dock.bulkLog(
+                    listOf(
+                        box(loggerName = "Source3", message = "from-dock1"),
+                        box(loggerName = "Source3", message = "from-dock2"),
+                    ).pack(),
+                )
+
+                awaitCondition { received.size >= 4 }
+
+                assertEquals(4, received.size)
+                assertTrue(received.any { it.loggerName == "Source1" })
+                assertTrue(received.any { it.loggerName == "Source2" })
+                assertEquals(2, received.count { it.loggerName == "Source3" })
+                collectJob.cancelAndJoin()
+                warehouse.close()
             }
-            delay(50)
-
-            drop1.log(box(loggerName = "Source1", message = "from-drop1"))
-            drop2.log(box(loggerName = "Source2", message = "from-drop2"))
-            dock.bulkLog(
-                listOf(
-                    box(loggerName = "Source3", message = "from-dock1"),
-                    box(loggerName = "Source3", message = "from-dock2"),
-                ).pack(),
-            )
-
-            awaitCondition { received.size >= 4 }
-
-            assertEquals(4, received.size)
-            assertTrue(received.any { it.loggerName == "Source1" })
-            assertTrue(received.any { it.loggerName == "Source2" })
-            assertEquals(2, received.count { it.loggerName == "Source3" })
-            collectJob.cancelAndJoin()
-            warehouse.close()
         }
-    }
 
     @Test
-    fun pipeline_withFiltering() = runTest {
-        withContext(Dispatchers.Default) {
-            val warehouse = Warehouse(DeliveryRates())
-            val dropBox = warehouse.requestPickup()
-            val service = warehouse.deliveries()
-            val filtered = service.weighIn(LevelFilter(LevelMatchMode.GT, Level.INFO))
+    fun pipeline_withFiltering() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates())
+                val dropBox = warehouse.requestPickup()
+                val service = warehouse.deliveries()
+                val filtered = service.weighIn(LevelFilter(LevelMatchMode.GT, Level.INFO))
 
-            val received = mutableListOf<Box>()
-            val collectJob = launch {
-                filtered.streamDeliveries().collect { received.add(it) }
+                val received = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        filtered.streamDeliveries().collect { received.add(it) }
+                    }
+                delay(50)
+
+                dropBox.log(box(level = Level.DEBUG, message = "skip-debug"))
+                dropBox.log(box(level = Level.INFO, message = "skip-info"))
+                dropBox.log(box(level = Level.WARN, message = "keep-warn"))
+                dropBox.log(box(level = Level.ERROR, message = "keep-error"))
+
+                awaitCondition { received.size >= 2 }
+
+                assertEquals(2, received.size)
+                assertEquals("keep-warn", received[0].message)
+                assertEquals("keep-error", received[1].message)
+                collectJob.cancelAndJoin()
+                warehouse.close()
             }
-            delay(50)
-
-            dropBox.log(box(level = Level.DEBUG, message = "skip-debug"))
-            dropBox.log(box(level = Level.INFO, message = "skip-info"))
-            dropBox.log(box(level = Level.WARN, message = "keep-warn"))
-            dropBox.log(box(level = Level.ERROR, message = "keep-error"))
-
-            awaitCondition { received.size >= 2 }
-
-            assertEquals(2, received.size)
-            assertEquals("keep-warn", received[0].message)
-            assertEquals("keep-error", received[1].message)
-            collectJob.cancelAndJoin()
-            warehouse.close()
         }
-    }
 
     @Test
-    fun pipeline_withBatchedDelivery() = runTest {
-        withContext(Dispatchers.Default) {
-            val rates = DeliveryRates(
-                defaultPaletteSize = 2,
-                defaultPaletteInterval = 100.seconds,
-            )
-            val warehouse = Warehouse(rates)
-            val dropBox = warehouse.requestPickup()
-            val service = warehouse.deliveries()
+    fun pipeline_withBatchedDelivery() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val rates =
+                    DeliveryRates(
+                        defaultPaletteSize = 2,
+                        defaultPaletteInterval = 100.seconds,
+                    )
+                val warehouse = Warehouse(rates)
+                val dropBox = warehouse.requestPickup()
+                val service = warehouse.deliveries()
 
-            val received = mutableListOf<Palette>()
-            val collectJob = launch {
-                service.streamDeliveriesPacked().collect { received.add(it) }
-            }
-            delay(50)
+                val received = mutableListOf<Palette>()
+                val collectJob =
+                    launch {
+                        service.streamDeliveriesPacked().collect { received.add(it) }
+                    }
+                delay(50)
 
-            dropBox.log(box(message = "batch-a"))
-            dropBox.log(box(message = "batch-b"))
+                dropBox.log(box(message = "batch-a"))
+                dropBox.log(box(message = "batch-b"))
 
-            awaitCondition("batched delivery received") {
+                awaitCondition("batched delivery received") {
+                    val allBoxes = received.flatMap { it.unpack() }
+                    allBoxes.size >= 2
+                }
+
                 val allBoxes = received.flatMap { it.unpack() }
-                allBoxes.size >= 2
+                assertTrue(allBoxes.any { it.message == "batch-a" })
+                assertTrue(allBoxes.any { it.message == "batch-b" })
+                collectJob.cancelAndJoin()
+                warehouse.close()
             }
-
-            val allBoxes = received.flatMap { it.unpack() }
-            assertTrue(allBoxes.any { it.message == "batch-a" })
-            assertTrue(allBoxes.any { it.message == "batch-b" })
-            collectJob.cancelAndJoin()
-            warehouse.close()
         }
-    }
 
     @Test
-    fun pipeline_metadataPreservedEndToEnd() = runTest {
-        withContext(Dispatchers.Default) {
-            val warehouse = Warehouse(DeliveryRates())
-            val dropBox = warehouse.requestPickup()
-            val service = warehouse.deliveries()
+    fun pipeline_metadataPreservedEndToEnd() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates())
+                val dropBox = warehouse.requestPickup()
+                val service = warehouse.deliveries()
 
-            val received = mutableListOf<Box>()
-            val collectJob = launch {
-                service.streamDeliveries().collect { received.add(it) }
+                val received = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        service.streamDeliveries().collect { received.add(it) }
+                    }
+                delay(50)
+
+                val meta = mapOf("requestId" to "abc-123", "userId" to "42")
+                dropBox.log(box(message = "with-meta").copy(metadata = meta))
+
+                awaitCondition { received.isNotEmpty() }
+
+                assertEquals(1, received.size)
+                assertEquals(meta, received[0].metadata)
+                collectJob.cancelAndJoin()
+                warehouse.close()
             }
-            delay(50)
-
-            val meta = mapOf("requestId" to "abc-123", "userId" to "42")
-            dropBox.log(box(message = "with-meta").copy(metadata = meta))
-
-            awaitCondition { received.isNotEmpty() }
-
-            assertEquals(1, received.size)
-            assertEquals(meta, received[0].metadata)
-            collectJob.cancelAndJoin()
-            warehouse.close()
         }
-    }
 
     @Test
-    fun pipeline_replayAndLiveDelivery() = runTest {
-        withContext(Dispatchers.Default) {
-            val warehouse = Warehouse(DeliveryRates(defaultBoxRetention = 100))
-            val dropBox = warehouse.requestPickup()
+    fun pipeline_replayAndLiveDelivery() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates(defaultBoxRetention = 100))
+                val dropBox = warehouse.requestPickup()
 
-            // Emit before subscribing — goes to replay cache
-            dropBox.log(box(message = "historical"))
+                // Emit before subscribing — goes to replay cache
+                dropBox.log(box(message = "historical"))
 
-            val service = warehouse.deliveries()
+                val service = warehouse.deliveries()
 
-            // Dump replay cache as a finite flow
-            val dumped = service.dumpDeliveries().toList()
-            assertEquals(1, dumped.size)
-            assertEquals("historical", dumped[0].message)
+                // Dump replay cache as a finite flow
+                val dumped = service.dumpDeliveries().toList()
+                assertEquals(1, dumped.size)
+                assertEquals("historical", dumped[0].message)
 
-            // Subscribe — SharedFlow replay means subscriber also gets cached events
-            val live = mutableListOf<Box>()
-            val collectJob = launch {
-                service.streamDeliveries().collect { live.add(it) }
+                // Subscribe — SharedFlow replay means subscriber also gets cached events
+                val live = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        service.streamDeliveries().collect { live.add(it) }
+                    }
+                delay(50)
+
+                dropBox.log(box(message = "live"))
+
+                awaitCondition("live delivery received") {
+                    live.any { it.message == "live" }
+                }
+
+                // Subscriber receives replayed "historical" + new "live"
+                assertTrue(live.any { it.message == "historical" })
+                assertTrue(live.any { it.message == "live" })
+                collectJob.cancelAndJoin()
+                warehouse.close()
             }
-            delay(50)
-
-            dropBox.log(box(message = "live"))
-
-            awaitCondition("live delivery received") {
-                live.any { it.message == "live" }
-            }
-
-            // Subscriber receives replayed "historical" + new "live"
-            assertTrue(live.any { it.message == "historical" })
-            assertTrue(live.any { it.message == "live" })
-            collectJob.cancelAndJoin()
-            warehouse.close()
         }
-    }
 }

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/SerializationTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/SerializationTest.kt
@@ -20,7 +20,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class SerializationTest {
-
     private val json = Json { encodeDefaults = true }
     private val jsonNoDefaults = Json { encodeDefaults = false }
 
@@ -101,14 +100,16 @@ class SerializationTest {
 
     @Test
     fun palette_roundtrip() {
-        val palette = Palette(
-            loggerNames = listOf("A", "B"),
-            threadNames = listOf("main"),
-            messages = listOf(
-                Package(20, 0, "msg1", 100L, 0),
-                Package(30, 1, "msg2", 200L, 0),
-            ),
-        )
+        val palette =
+            Palette(
+                loggerNames = listOf("A", "B"),
+                threadNames = listOf("main"),
+                messages =
+                    listOf(
+                        Package(20, 0, "msg1", 100L, 0),
+                        Package(30, 1, "msg2", 200L, 0),
+                    ),
+            )
         val encoded = json.encodeToString(Palette.serializer(), palette)
         val decoded = json.decodeFromString(Palette.serializer(), encoded)
         assertEquals(palette, decoded)
@@ -116,10 +117,11 @@ class SerializationTest {
 
     @Test
     fun palette_emptyThreadNames_defaultOnDecode() {
-        val palette = Palette(
-            loggerNames = listOf("A"),
-            messages = listOf(Package(20, 0, "msg", 100L, null)),
-        )
+        val palette =
+            Palette(
+                loggerNames = listOf("A"),
+                messages = listOf(Package(20, 0, "msg", 100L, null)),
+            )
         val encoded = jsonNoDefaults.encodeToString(Palette.serializer(), palette)
         val decoded = jsonNoDefaults.decodeFromString(Palette.serializer(), encoded)
         assertEquals(palette, decoded)
@@ -129,10 +131,11 @@ class SerializationTest {
 
     @Test
     fun palette_jsonRoundtrip_matchesPackUnpack() {
-        val boxes = listOf(
-            Box(Level.INFO, "com.example.A", "hello", 1000L, "main"),
-            Box(Level.ERROR, "com.example.B", "fail", 2000L, "worker"),
-        )
+        val boxes =
+            listOf(
+                Box(Level.INFO, "com.example.A", "hello", 1000L, "main"),
+                Box(Level.ERROR, "com.example.B", "fail", 2000L, "worker"),
+            )
         val palette = boxes.pack()
         val encoded = json.encodeToString(Palette.serializer(), palette)
         val decoded = json.decodeFromString(Palette.serializer(), encoded)
@@ -183,10 +186,11 @@ class SerializationTest {
 
     @Test
     fun andFilter_roundtrip() {
-        val filter: WeighStation = AndFilter(
-            LevelFilter(LevelMatchMode.GT, Level.DEBUG),
-            LoggerNameFilter(LoggerMatchMode.PREFIX, "com"),
-        )
+        val filter: WeighStation =
+            AndFilter(
+                LevelFilter(LevelMatchMode.GT, Level.DEBUG),
+                LoggerNameFilter(LoggerMatchMode.PREFIX, "com"),
+            )
         val encoded = json.encodeToString(WeighStation.serializer(), filter)
         val decoded = json.decodeFromString(WeighStation.serializer(), encoded)
         assertEquals(filter, decoded)
@@ -194,10 +198,11 @@ class SerializationTest {
 
     @Test
     fun orFilter_roundtrip() {
-        val filter: WeighStation = OrFilter(
-            LevelFilter(LevelMatchMode.EQ, Level.ERROR),
-            MessageFilter(LoggerMatchMode.EXACT, "critical"),
-        )
+        val filter: WeighStation =
+            OrFilter(
+                LevelFilter(LevelMatchMode.EQ, Level.ERROR),
+                MessageFilter(LoggerMatchMode.EXACT, "critical"),
+            )
         val encoded = json.encodeToString(WeighStation.serializer(), filter)
         val decoded = json.decodeFromString(WeighStation.serializer(), encoded)
         assertEquals(filter, decoded)
@@ -213,13 +218,14 @@ class SerializationTest {
 
     @Test
     fun nestedFilter_roundtrip() {
-        val filter: WeighStation = AndFilter(
-            OrFilter(
-                LevelFilter(LevelMatchMode.GT, Level.INFO),
-                LoggerNameFilter(LoggerMatchMode.PREFIX, "com.example"),
-            ),
-            NotFilter(MessageFilter(LoggerMatchMode.REGEX, ".*ignore.*")),
-        )
+        val filter: WeighStation =
+            AndFilter(
+                OrFilter(
+                    LevelFilter(LevelMatchMode.GT, Level.INFO),
+                    LoggerNameFilter(LoggerMatchMode.PREFIX, "com.example"),
+                ),
+                NotFilter(MessageFilter(LoggerMatchMode.REGEX, ".*ignore.*")),
+            )
         val encoded = json.encodeToString(WeighStation.serializer(), filter)
         val decoded = json.decodeFromString(WeighStation.serializer(), encoded)
         assertEquals(filter, decoded)

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/ServiceTierWireTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/ServiceTierWireTest.kt
@@ -42,89 +42,95 @@ import kotlin.time.Duration.Companion.seconds
  * Also exercises the Flow<T> auto-detection in @KsService methods (streamDeliveries).
  */
 class ServiceTierWireTest {
-
-    private fun box(level: Level = Level.INFO, message: String = "msg") =
-        Box(level, "logger", message, 0L, "main")
-
-    @Test
-    fun shipperOverWire_pickupAndStream() = runTest {
-        withContext(Dispatchers.Default) {
-            val warehouse = Warehouse(DeliveryRates())
-            val (shipper, channel) = hostShipper(warehouse)
-            try {
-                val dropBox = shipper.requestPickup()
-                val service = shipper.deliveries()
-                val received = mutableListOf<Box>()
-                val collectJob = launch {
-                    service.streamDeliveries().collect { received.add(it) }
-                }
-                delay(100)
-                dropBox.log(box(message = "hi"))
-                withTimeout(5.seconds) {
-                    while (received.isEmpty()) delay(5)
-                }
-                assertEquals(1, received.size)
-                assertEquals("hi", received[0].message)
-                collectJob.cancelAndJoin()
-            } finally {
-                runCatching { channel.close() }
-                warehouse.close()
-            }
-        }
-    }
+    private fun box(
+        level: Level = Level.INFO,
+        message: String = "msg",
+    ) = Box(level, "logger", message, 0L, "main")
 
     @Test
-    fun weighInOverWire_filteredViewKeepsBidiCapability() = runTest {
-        withContext(Dispatchers.Default) {
-            val warehouse = Warehouse(DeliveryRates())
-            val (shipper, channel) = hostShipper(warehouse)
-            try {
-                val dropBox = shipper.requestPickup()
-                val service = shipper.deliveries()
-                val filtered: DeliveryService =
-                    service.weighIn(LevelFilter(LevelMatchMode.GT, Level.INFO))
-
-                val received = mutableListOf<Box>()
-                val collectJob = launch {
-                    filtered.streamDeliveries().collect { received.add(it) }
+    fun shipperOverWire_pickupAndStream() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates())
+                val (shipper, channel) = hostShipper(warehouse)
+                try {
+                    val dropBox = shipper.requestPickup()
+                    val service = shipper.deliveries()
+                    val received = mutableListOf<Box>()
+                    val collectJob =
+                        launch {
+                            service.streamDeliveries().collect { received.add(it) }
+                        }
+                    delay(100)
+                    dropBox.log(box(message = "hi"))
+                    withTimeout(5.seconds) {
+                        while (received.isEmpty()) delay(5)
+                    }
+                    assertEquals(1, received.size)
+                    assertEquals("hi", received[0].message)
+                    collectJob.cancelAndJoin()
+                } finally {
+                    runCatching { channel.close() }
+                    warehouse.close()
                 }
-                delay(100)
-                dropBox.log(box(level = Level.DEBUG, message = "skip-debug"))
-                dropBox.log(box(level = Level.INFO, message = "skip-info"))
-                dropBox.log(box(level = Level.WARN, message = "keep-warn"))
-                dropBox.log(box(level = Level.ERROR, message = "keep-error"))
-
-                withTimeout(5.seconds) {
-                    while (received.size < 2) delay(5)
-                }
-                assertEquals(2, received.size)
-                assertEquals("keep-warn", received[0].message)
-                assertEquals("keep-error", received[1].message)
-                collectJob.cancelAndJoin()
-            } finally {
-                runCatching { channel.close() }
-                warehouse.close()
             }
         }
-    }
 
     @Test
-    fun basicShipperStubExposesOnlyHostMethods() = runTest {
-        withContext(Dispatchers.Default) {
-            val warehouse = Warehouse(DeliveryRates())
-            val (basic, channel) = hostBasicShipper(warehouse)
-            try {
-                val dropBox = basic.requestPickup()
-                val dock = basic.requestDockPickup()
-                assertTrue(true, "BasicShipper round-trip OK; both methods callable")
-                dropBox.log(box(message = "via basic"))
-                dock.bulkLog(Palette(loggerNames = emptyList(), messages = emptyList()))
-            } finally {
-                runCatching { channel.close() }
-                warehouse.close()
+    fun weighInOverWire_filteredViewKeepsBidiCapability() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates())
+                val (shipper, channel) = hostShipper(warehouse)
+                try {
+                    val dropBox = shipper.requestPickup()
+                    val service = shipper.deliveries()
+                    val filtered: DeliveryService =
+                        service.weighIn(LevelFilter(LevelMatchMode.GT, Level.INFO))
+
+                    val received = mutableListOf<Box>()
+                    val collectJob =
+                        launch {
+                            filtered.streamDeliveries().collect { received.add(it) }
+                        }
+                    delay(100)
+                    dropBox.log(box(level = Level.DEBUG, message = "skip-debug"))
+                    dropBox.log(box(level = Level.INFO, message = "skip-info"))
+                    dropBox.log(box(level = Level.WARN, message = "keep-warn"))
+                    dropBox.log(box(level = Level.ERROR, message = "keep-error"))
+
+                    withTimeout(5.seconds) {
+                        while (received.size < 2) delay(5)
+                    }
+                    assertEquals(2, received.size)
+                    assertEquals("keep-warn", received[0].message)
+                    assertEquals("keep-error", received[1].message)
+                    collectJob.cancelAndJoin()
+                } finally {
+                    runCatching { channel.close() }
+                    warehouse.close()
+                }
             }
         }
-    }
+
+    @Test
+    fun basicShipperStubExposesOnlyHostMethods() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates())
+                val (basic, channel) = hostBasicShipper(warehouse)
+                try {
+                    val dropBox = basic.requestPickup()
+                    val dock = basic.requestDockPickup()
+                    assertTrue(true, "BasicShipper round-trip OK; both methods callable")
+                    dropBox.log(box(message = "via basic"))
+                    dock.bulkLog(Palette(loggerNames = emptyList(), messages = emptyList()))
+                } finally {
+                    runCatching { channel.close() }
+                    warehouse.close()
+                }
+            }
+        }
 
     private suspend fun hostShipper(warehouse: Warehouse): Pair<Shipper, HostSerializedChannelImpl<String>> {
         val channel = HostSerializedChannelImpl(ksrpcEnvironment { })
@@ -133,9 +139,7 @@ class ServiceTierWireTest {
         return stub to channel
     }
 
-    private suspend fun hostBasicShipper(
-        warehouse: Warehouse,
-    ): Pair<BasicShipper, HostSerializedChannelImpl<String>> {
+    private suspend fun hostBasicShipper(warehouse: Warehouse): Pair<BasicShipper, HostSerializedChannelImpl<String>> {
         val channel = HostSerializedChannelImpl(ksrpcEnvironment { })
         channel.registerDefault(warehouse, BasicShipper)
         val stub: BasicShipper = channel.asClient.defaultChannel().toStub()

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/TerminatorsTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/TerminatorsTest.kt
@@ -25,7 +25,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class TerminatorsTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",
@@ -35,91 +34,99 @@ class TerminatorsTest {
     ) = Box(level, loggerName, message, timestamp, threadName)
 
     @Test
-    fun defaultFormat_singleLine() = runTest {
-        val lines = mutableListOf<String>()
-        val collector = FlowCollector<String> { lines.add(it) }
-        collector.defaultFormat(box(message = "hello world"))
+    fun defaultFormat_singleLine() =
+        runTest {
+            val lines = mutableListOf<String>()
+            val collector = FlowCollector<String> { lines.add(it) }
+            collector.defaultFormat(box(message = "hello world"))
 
-        assertEquals(1, lines.size)
-        assertTrue(lines[0].contains("hello world"))
-        assertTrue(lines[0].contains("com.example.Test"))
-        assertTrue(lines[0].contains("main"))
-    }
-
-    @Test
-    fun defaultFormat_multiLine() = runTest {
-        val lines = mutableListOf<String>()
-        val collector = FlowCollector<String> { lines.add(it) }
-        collector.defaultFormat(box(message = "line1\nline2\nline3"))
-
-        assertEquals(3, lines.size)
-        assertTrue(lines[0].contains("line1"))
-        assertTrue(lines[1].contains("line2"))
-        assertTrue(lines[2].contains("line3"))
-    }
+            assertEquals(1, lines.size)
+            assertTrue(lines[0].contains("hello world"))
+            assertTrue(lines[0].contains("com.example.Test"))
+            assertTrue(lines[0].contains("main"))
+        }
 
     @Test
-    fun defaultFormat_multiLineSharesPrefix() = runTest {
-        val lines = mutableListOf<String>()
-        val collector = FlowCollector<String> { lines.add(it) }
-        collector.defaultFormat(box(message = "XLINE1\nXLINE2", loggerName = "MyLogger"))
+    fun defaultFormat_multiLine() =
+        runTest {
+            val lines = mutableListOf<String>()
+            val collector = FlowCollector<String> { lines.add(it) }
+            collector.defaultFormat(box(message = "line1\nline2\nline3"))
 
-        // Both lines should share the same prefix
-        val prefix1 = lines[0].substringBefore("XLINE1")
-        val prefix2 = lines[1].substringBefore("XLINE2")
-        assertEquals(prefix1, prefix2)
-        assertTrue(prefix1.contains("MyLogger"))
-    }
-
-    @Test
-    fun defaultFormat_nullThreadName() = runTest {
-        val lines = mutableListOf<String>()
-        val collector = FlowCollector<String> { lines.add(it) }
-        collector.defaultFormat(box(threadName = null, message = "msg"))
-
-        assertEquals(1, lines.size)
-        assertTrue(lines[0].contains("null"))
-        assertTrue(lines[0].contains("msg"))
-    }
+            assertEquals(3, lines.size)
+            assertTrue(lines[0].contains("line1"))
+            assertTrue(lines[1].contains("line2"))
+            assertTrue(lines[2].contains("line3"))
+        }
 
     @Test
-    fun route_collectsFormattedOutput() = runTest {
-        val deliveries = flowOf(box(message = "hello"))
-        val output = mutableListOf<String>()
-        val display: Display = FlowCollector { output.add(it) }
+    fun defaultFormat_multiLineSharesPrefix() =
+        runTest {
+            val lines = mutableListOf<String>()
+            val collector = FlowCollector<String> { lines.add(it) }
+            collector.defaultFormat(box(message = "XLINE1\nXLINE2", loggerName = "MyLogger"))
 
-        deliveries.route(display)
-
-        assertEquals(1, output.size)
-        assertTrue(output[0].contains("hello"))
-    }
-
-    @Test
-    fun route_customFormatter() = runTest {
-        val deliveries = flowOf(box(message = "hello"))
-        val output = mutableListOf<String>()
-        val display: Display = FlowCollector { output.add(it) }
-        val formatter: Formatter = { box -> emit("[${box.level}] ${box.message}") }
-
-        deliveries.route(display, formatter)
-
-        assertEquals(1, output.size)
-        assertEquals("[INFO] hello", output[0])
-    }
+            // Both lines should share the same prefix
+            val prefix1 = lines[0].substringBefore("XLINE1")
+            val prefix2 = lines[1].substringBefore("XLINE2")
+            assertEquals(prefix1, prefix2)
+            assertTrue(prefix1.contains("MyLogger"))
+        }
 
     @Test
-    fun route_multipleBoxes() = runTest {
-        val deliveries = flowOf(
-            box(message = "first"),
-            box(message = "second"),
-        )
-        val output = mutableListOf<String>()
-        val display: Display = FlowCollector { output.add(it) }
+    fun defaultFormat_nullThreadName() =
+        runTest {
+            val lines = mutableListOf<String>()
+            val collector = FlowCollector<String> { lines.add(it) }
+            collector.defaultFormat(box(threadName = null, message = "msg"))
 
-        deliveries.route(display)
+            assertEquals(1, lines.size)
+            assertTrue(lines[0].contains("null"))
+            assertTrue(lines[0].contains("msg"))
+        }
 
-        assertEquals(2, output.size)
-        assertTrue(output[0].contains("first"))
-        assertTrue(output[1].contains("second"))
-    }
+    @Test
+    fun route_collectsFormattedOutput() =
+        runTest {
+            val deliveries = flowOf(box(message = "hello"))
+            val output = mutableListOf<String>()
+            val display: Display = FlowCollector { output.add(it) }
+
+            deliveries.route(display)
+
+            assertEquals(1, output.size)
+            assertTrue(output[0].contains("hello"))
+        }
+
+    @Test
+    fun route_customFormatter() =
+        runTest {
+            val deliveries = flowOf(box(message = "hello"))
+            val output = mutableListOf<String>()
+            val display: Display = FlowCollector { output.add(it) }
+            val formatter: Formatter = { box -> emit("[${box.level}] ${box.message}") }
+
+            deliveries.route(display, formatter)
+
+            assertEquals(1, output.size)
+            assertEquals("[INFO] hello", output[0])
+        }
+
+    @Test
+    fun route_multipleBoxes() =
+        runTest {
+            val deliveries =
+                flowOf(
+                    box(message = "first"),
+                    box(message = "second"),
+                )
+            val output = mutableListOf<String>()
+            val display: Display = FlowCollector { output.add(it) }
+
+            deliveries.route(display)
+
+            assertEquals(2, output.size)
+            assertTrue(output[0].contains("first"))
+            assertTrue(output[1].contains("second"))
+        }
 }

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/TrucksTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/TrucksTest.kt
@@ -20,7 +20,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class TrucksTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",
@@ -30,29 +29,32 @@ class TrucksTest {
     ) = Box(level, loggerName, message, timestamp, threadName)
 
     @Test
-    fun container_silentlyDiscardsBoxes() = runTest {
-        // Container should not throw; it just discards
-        Container.emit(box(message = "discarded"))
-        Container.emit(box(message = "also discarded"))
-    }
-
-    @Test
-    fun container_multipleEmitsNoEffect() = runTest {
-        // Emitting many boxes should still be a no-op
-        repeat(1000) {
-            Container.emit(box(message = "msg$it"))
+    fun container_silentlyDiscardsBoxes() =
+        runTest {
+            // Container should not throw; it just discards
+            Container.emit(box(message = "discarded"))
+            Container.emit(box(message = "also discarded"))
         }
-        // No assertions needed — just verifying it doesn't throw or leak
-    }
 
     @Test
-    fun flatbed_emitsToStdout() = runTest {
-        // Flatbed wraps println; just verify it doesn't throw
-        // We can't easily capture stdout in common code, so just verify the contract
-        val collected = mutableListOf<String>()
-        val testDisplay: Display = Display { collected.add(it) }
-        testDisplay.emit("hello")
-        assertEquals(1, collected.size)
-        assertEquals("hello", collected[0])
-    }
+    fun container_multipleEmitsNoEffect() =
+        runTest {
+            // Emitting many boxes should still be a no-op
+            repeat(1000) {
+                Container.emit(box(message = "msg$it"))
+            }
+            // No assertions needed — just verifying it doesn't throw or leak
+        }
+
+    @Test
+    fun flatbed_emitsToStdout() =
+        runTest {
+            // Flatbed wraps println; just verify it doesn't throw
+            // We can't easily capture stdout in common code, so just verify the contract
+            val collected = mutableListOf<String>()
+            val testDisplay: Display = Display { collected.add(it) }
+            testDisplay.emit("hello")
+            assertEquals(1, collected.size)
+            assertEquals("hello", collected[0])
+        }
 }

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/WarehouseTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/WarehouseTest.kt
@@ -29,7 +29,6 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
 class WarehouseTest {
-
     private fun box(
         level: Level = Level.INFO,
         loggerName: String = "com.example.Test",
@@ -45,101 +44,109 @@ class WarehouseTest {
     }
 
     @Test
-    fun dropBox_sendsToDelivery() = runTest {
-        withContext(Dispatchers.Default) {
-            val warehouse = Warehouse(DeliveryRates())
+    fun dropBox_sendsToDelivery() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates())
+                val dropBox = warehouse.requestPickup()
+                val deliveryService = warehouse.deliveries()
+
+                val received = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        deliveryService.streamDeliveries().collect { received.add(it) }
+                    }
+                delay(50) // let collection settle
+
+                val testBox = box(message = "hello")
+                dropBox.log(testBox)
+                awaitCondition { received.isNotEmpty() }
+                assertEquals(listOf(testBox), received)
+                collectJob.cancelAndJoin()
+                warehouse.close()
+            }
+        }
+
+    @Test
+    fun loadingDock_sendsToDelivery() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates())
+                val dock = warehouse.requestDockPickup()
+                val deliveryService = warehouse.deliveries()
+
+                val received = mutableListOf<Box>()
+                val boxes = listOf(box(message = "a"), box(message = "b"))
+                val collectJob =
+                    launch {
+                        deliveryService.streamDeliveries().collect { received.add(it) }
+                    }
+                delay(50)
+
+                dock.bulkLog(boxes.pack())
+                awaitCondition { received.size >= 2 }
+                assertEquals(boxes, received)
+                collectJob.cancelAndJoin()
+                warehouse.close()
+            }
+        }
+
+    @Test
+    fun replayCache_returnsHistoricalLogs() =
+        runTest {
+            val warehouse = Warehouse(DeliveryRates(defaultBoxRetention = 100))
             val dropBox = warehouse.requestPickup()
-            val deliveryService = warehouse.deliveries()
-
-            val received = mutableListOf<Box>()
-            val collectJob = launch {
-                deliveryService.streamDeliveries().collect { received.add(it) }
-            }
-            delay(50) // let collection settle
-
-            val testBox = box(message = "hello")
+            val testBox = box(message = "historical")
             dropBox.log(testBox)
-            awaitCondition { received.isNotEmpty() }
+
+            val deliveryService = warehouse.deliveries()
+            val received = deliveryService.dumpDeliveries().toList()
             assertEquals(listOf(testBox), received)
-            collectJob.cancelAndJoin()
             warehouse.close()
         }
-    }
 
     @Test
-    fun loadingDock_sendsToDelivery() = runTest {
-        withContext(Dispatchers.Default) {
-            val warehouse = Warehouse(DeliveryRates())
-            val dock = warehouse.requestDockPickup()
-            val deliveryService = warehouse.deliveries()
+    fun multipleDropBoxes_allFeedSameFlow() =
+        runTest {
+            withContext(Dispatchers.Default) {
+                val warehouse = Warehouse(DeliveryRates())
+                val drop1 = warehouse.requestPickup()
+                val drop2 = warehouse.requestPickup()
+                val deliveryService = warehouse.deliveries()
 
-            val received = mutableListOf<Box>()
-            val boxes = listOf(box(message = "a"), box(message = "b"))
-            val collectJob = launch {
-                deliveryService.streamDeliveries().collect { received.add(it) }
+                val received = mutableListOf<Box>()
+                val collectJob =
+                    launch {
+                        deliveryService.streamDeliveries().collect { received.add(it) }
+                    }
+                delay(50)
+
+                drop1.log(box(message = "from1"))
+                drop2.log(box(message = "from2"))
+                awaitCondition { received.size >= 2 }
+                assertEquals(2, received.size)
+                assertTrue(received.any { it.message == "from1" })
+                assertTrue(received.any { it.message == "from2" })
+                collectJob.cancelAndJoin()
+                warehouse.close()
             }
-            delay(50)
-
-            dock.bulkLog(boxes.pack())
-            awaitCondition { received.size >= 2 }
-            assertEquals(boxes, received)
-            collectJob.cancelAndJoin()
-            warehouse.close()
         }
-    }
 
     @Test
-    fun replayCache_returnsHistoricalLogs() = runTest {
-        val warehouse = Warehouse(DeliveryRates(defaultBoxRetention = 100))
-        val dropBox = warehouse.requestPickup()
-        val testBox = box(message = "historical")
-        dropBox.log(testBox)
-
-        val deliveryService = warehouse.deliveries()
-        val received = deliveryService.dumpDeliveries().toList()
-        assertEquals(listOf(testBox), received)
-        warehouse.close()
-    }
-
-    @Test
-    fun multipleDropBoxes_allFeedSameFlow() = runTest {
-        withContext(Dispatchers.Default) {
+    fun close_preventsNewPickups() =
+        runTest {
             val warehouse = Warehouse(DeliveryRates())
-            val drop1 = warehouse.requestPickup()
-            val drop2 = warehouse.requestPickup()
-            val deliveryService = warehouse.deliveries()
-
-            val received = mutableListOf<Box>()
-            val collectJob = launch {
-                deliveryService.streamDeliveries().collect { received.add(it) }
-            }
-            delay(50)
-
-            drop1.log(box(message = "from1"))
-            drop2.log(box(message = "from2"))
-            awaitCondition { received.size >= 2 }
-            assertEquals(2, received.size)
-            assertTrue(received.any { it.message == "from1" })
-            assertTrue(received.any { it.message == "from2" })
-            collectJob.cancelAndJoin()
             warehouse.close()
+            // After close, the internal scope is cancelled.
+            // Requesting new pickups should fail since the scope is cancelled.
+            val caught = runCatching { warehouse.requestPickup() }
+            // DropBox creation itself may succeed (it's just object creation),
+            // but emitting through it should fail because the scope is cancelled.
+            if (caught.isSuccess) {
+                val dropBox = caught.getOrThrow()
+                // Emitting after close should either throw or silently drop
+                runCatching { dropBox.log(box(message = "after close")) }
+                // We don't mandate the exact failure mode, just verify close() ran
+            }
         }
-    }
-
-    @Test
-    fun close_preventsNewPickups() = runTest {
-        val warehouse = Warehouse(DeliveryRates())
-        warehouse.close()
-        // After close, the internal scope is cancelled.
-        // Requesting new pickups should fail since the scope is cancelled.
-        val caught = runCatching { warehouse.requestPickup() }
-        // DropBox creation itself may succeed (it's just object creation),
-        // but emitting through it should fail because the scope is cancelled.
-        if (caught.isSuccess) {
-            val dropBox = caught.getOrThrow()
-            // Emitting after close should either throw or silently drop
-            runCatching { dropBox.log(box(message = "after close")) }
-            // We don't mandate the exact failure mode, just verify close() ran
-        }
-    }
 }


### PR DESCRIPTION
## Summary
Pure `ktlintFormat` pass to clear the **pre-existing ktlint debt** on `main`. hauler's only workflow is `publish.yaml` (release-triggered, never runs `ktlintCheck`) and there's no `pull_request` CI, so `:hauler:build`'s ktlint gate has been red on `main` and style drift accumulated unnoticed.

Ran `./gradlew ktlintFormat`; the fixes are:
- `multiline-expression-wrapping` (Conversions, CustomerPickupImpl, Terminators, root `build.gradle.kts`)
- `function-signature` wrapping (FilterBuilder)
- `import-ordering` (Filters)
- `no-blank-line-before-rbrace` (Garage)
- assorted wrapping/whitespace across the `commonTest` suite

**Pure formatting — zero logic, behavior, or API change.** (This is the first of the two debt-clearing items; the companion PR wires up `pull_request` CI so this can't silently regress again.)

## Verification (JDK 21)
```
./gradlew :hauler:check ktlintCheck -x klibApiCheck
```
→ **BUILD SUCCESSFUL**, **0 ktlint violations** repo-wide. `:hauler:check` compiles all host-runnable targets and runs tests + JVM `apiCheck` + license check, all green.

## Scope notes (deliberately out of scope)
- **`klibApiCheck`**: BCV's native-klib pipeline is skipped on Linux and no klib baseline is committed — orthogonal to formatting; needs a macOS-generated baseline (flagged separately).
- **`:benchmark` module**: pre-existingly broken against the 0.4.x Flow API (references the removed `dumpDeliveries`/`deliveries(scope,rates)` callback API). Not touched here; flagged as a separate debt.