### PR TITLE
Add pull-request / main CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,46 @@
+# Pull-request / main CI gate.
+#
+# Until now hauler's only workflow was publish.yaml (release-triggered), so PRs
+# got no automated checks and style/build debt could accumulate silently. This
+# runs the verifiable gate on every PR and on pushes to main.
+#
+# Scope notes:
+#   * Runs on ubuntu-latest. The JVM/JS/WASM/Linux/MinGW targets build and test
+#     here; the Apple targets (macOS/iOS) are skipped on a non-mac host — they
+#     are still covered at release time by publish.yaml (macos-latest). Adding a
+#     dedicated macOS compile job for the Apple targets is a sensible follow-up.
+#   * `-x klibApiCheck`: BCV's native-klib ABI check needs all targets (incl.
+#     Apple) to build, so it only works on macOS, and no klib baseline is
+#     committed yet. The JVM `apiCheck` (run via :hauler:check) still gates the
+#     public API. Committing a macOS-generated klib baseline to enable
+#     klibApiCheck is a follow-up.
+#   * Only :hauler (the published library) is built. The :benchmark module is
+#     pre-existingly broken against the 0.4.x Flow API and is intentionally not
+#     part of the gate; ktlintCheck still covers its source style.
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Assemble, test, apiCheck, ktlint
+        run: ./gradlew :hauler:assemble :hauler:check ktlintCheck -x klibApiCheck


### PR DESCRIPTION
## Summary
Closes the **no-PR-CI gap**: hauler's only workflow was `publish.yaml` (release-triggered), so PRs got no remote checks and build/style debt accumulated silently (the ktlint debt just cleared in #8; the broken `:benchmark` module). This adds `.github/workflows/ci.yaml` running on every `pull_request` and `push` to `main`:

```
./gradlew :hauler:assemble :hauler:check ktlintCheck -x klibApiCheck
```

That gate compiles all host-buildable targets (JVM / JS / WASM / Linux / MinGW), runs the tests, the **JVM `apiCheck`** (BCV public-API gate), the license-header check, and **`ktlintCheck`** across the whole repo. Mirrors `publish.yaml`'s JDK-21 / temurin / `setup-gradle` setup; adds a `concurrency` group so superseded runs cancel.

This PR self-validates: the workflow runs on its own PR, against the now-ktlint-clean `main`.

## Verified locally (JDK 21)
`./gradlew :hauler:assemble :hauler:check ktlintCheck -x klibApiCheck` → **BUILD SUCCESSFUL**.

## Deliberate scope (documented inline in the workflow) + follow-ups
- **ubuntu-latest** — Apple (macOS/iOS) targets skip on a non-mac host; they stay covered at release by `publish.yaml`. Kept out here so the gate is reliably green. **Follow-up:** a dedicated `macos-latest` Apple-compile job (low risk, but needs a macOS run to confirm green before enabling).
- **`-x klibApiCheck`** — BCV's native-klib ABI check needs all targets (incl. Apple) plus a committed klib baseline, neither available on Linux; the JVM `apiCheck` still gates the API. **Follow-up:** generate + commit a macOS klib baseline to turn on `klibApiCheck`.
- **`:hauler` only** — the `:benchmark` module is pre-existingly broken against the 0.4.x Flow API (stale `dumpDeliveries`/`deliveries(scope,rates)` usage). Not gated here; `ktlintCheck` still covers its style. **Follow-up:** port `:benchmark` to the 0.4.x API or retire it.

These three follow-ups are filed-worthy as separate health items; flagging here for visibility.