### PR TITLE
Default Garage.route formatter to the DefaultFormat constant (#12)

### DIFF
--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Garage.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Garage.kt
@@ -17,7 +17,6 @@ package com.monkopedia.hauler
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
@@ -74,7 +73,7 @@ inline fun <reified T> createHauler(): Hauler = hauler(T::class.simpleName ?: T:
 fun route(
     scope: CoroutineScope,
     display: Display,
-    formatter: Formatter = FlowCollector<String>::defaultFormat,
+    formatter: Formatter = DefaultFormat,
 ): Job =
     scope.launch {
         Garage.deliveries.route(display, formatter)


### PR DESCRIPTION
`Garage.route(scope, display, formatter)` defaulted its `formatter` parameter to the raw callable reference `FlowCollector<String>::defaultFormat`, while the three other `route` overloads (both `Deliveries.route` overloads in Terminators.kt) default to the named public constant `DefaultFormat` (declared as `val DefaultFormat: Formatter = FlowCollector<String>::defaultFormat`).

This aligns the fourth overload with the other three (`formatter: Formatter = DefaultFormat`) and drops the now-unused `FlowCollector` import from Garage.kt.

Same resolved default value — no behavior change and no public API/ABI change (JVM apiCheck unaffected; default-value expressions aren't part of the ABI).

Fixes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)