### PR TITLE
Deduplicate withPickup / dumpWithPickup polling bodies (#10)

### DIFF
--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Flows.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Flows.kt
@@ -28,32 +28,27 @@ fun BasicDeliveryService.withPickup(
     interval: Duration = 500.milliseconds,
     maxEntries: Int = 100,
     closeScope: CoroutineScope,
-): Deliveries =
-    callbackFlow {
-        val polling = recurringCustomerPickup()
-        launch {
-            while (true) {
-                polling.get(maxEntries = maxEntries).forEach {
-                    send(it)
-                }
-                delay(interval)
-            }
-        }
-        awaitClose {
-            closeScope.launch {
-                polling.close()
-            }
-        }
-    }
+): Deliveries = pollingDeliveries(interval, maxEntries, closeScope) { recurringCustomerPickup() }
 
 /** Drain the replay cache by polling, as a [Deliveries] flow. */
 fun BasicDeliveryService.dumpWithPickup(
     interval: Duration = 500.milliseconds,
     maxEntries: Int = 100,
     closeScope: CoroutineScope,
+): Deliveries = pollingDeliveries(interval, maxEntries, closeScope) { dumpCustomerPickup() }
+
+/**
+ * Poll [pickup] into a [Deliveries] flow, emitting up to [maxEntries] per [interval] and closing
+ * the pickup on [closeScope] when the flow is cancelled. Shared by [withPickup] and [dumpWithPickup].
+ */
+private fun pollingDeliveries(
+    interval: Duration,
+    maxEntries: Int,
+    closeScope: CoroutineScope,
+    pickup: suspend () -> CustomerPickup,
 ): Deliveries =
     callbackFlow {
-        val polling = dumpCustomerPickup()
+        val polling = pickup()
         launch {
             while (true) {
                 polling.get(maxEntries = maxEntries).forEach {


### PR DESCRIPTION
`BasicDeliveryService.withPickup` and `dumpWithPickup` had byte-identical `callbackFlow` polling bodies (same poll loop, `send`, `delay`, and `awaitClose`/close semantics), differing only in which pickup they open — `recurringCustomerPickup()` vs `dumpCustomerPickup()`.

Extracted the shared body into a private `pollingDeliveries(interval, maxEntries, closeScope, pickup)` helper taking a `suspend () -> CustomerPickup`; both public functions become one-line delegations that pass `{ recurringCustomerPickup() }` / `{ dumpCustomerPickup() }`. One place to maintain the polling loop / close semantics instead of two copies kept in lockstep.

Public signatures are unchanged — no API/ABI change.

Fixes #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)