### PR TITLE
Implement List<Box>.pack() via LogPacker (#11)

### DIFF
--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Conversions.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Conversions.kt
@@ -26,29 +26,7 @@ import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.flow.transform
 
 /** Compress a list of [Box]es into a [Palette] for efficient transport, deduplicating logger and thread names. */
-fun List<Box>.pack(): Palette {
-    val tagsIndex = hashMapOf<String, Int>()
-    val tagsList = mutableListOf<String>()
-    val threadsIndex = hashMapOf<String, Int>()
-    val threadsList = mutableListOf<String>()
-    val packages = ArrayList<Package>(size)
-    for (box in this) {
-        val tagIdx =
-            tagsIndex.getOrPut(box.loggerName) {
-                tagsList.size.also { tagsList.add(box.loggerName) }
-            }
-        val threadIdx =
-            box.threadName?.let { name ->
-                threadsIndex.getOrPut(name) {
-                    threadsList.size.also { threadsList.add(name) }
-                }
-            }
-        packages.add(
-            Package(box.level.intLevel, tagIdx, box.message, box.timestamp, threadIdx, box.metadata),
-        )
-    }
-    return Palette(tagsList, threadsList, packages)
-}
+fun List<Box>.pack(): Palette = LogPacker().also { packer -> forEach(packer::log) }.dumpLogs()
 
 /** Batch a stream of [Box]es into [Palette]s, flushing by size or time interval. */
 fun Deliveries.pack(deliveryRates: DeliveryRates = DeliveryRates(onDeliveryError = {})): Flow<Palette> {


### PR DESCRIPTION
`List<Box>.pack()` reimplemented the same logger/thread-name interning-into-`Package` logic that `LogPacker.log()` already performs — two copies of the `getOrPut` interning dance that had to be kept in lockstep. Since `LogPacker` is `internal`, `pack()` now delegates to it:

```kotlin
fun List<Box>.pack(): Palette = LogPacker().also { packer -> forEach(packer::log) }.dumpLogs()
```

Single source of truth for the interning/packing algorithm; `pack()`'s public signature is unchanged (implementation-only, no API/ABI change). Existing pack/unpack round-trip tests cover the behavior.

Fixes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)