### PR TITLE
Reconcile loggingName() thread-name attribution on JVM (#13)

### DIFF
--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/CallSign.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/CallSign.kt
@@ -28,8 +28,9 @@ import kotlin.coroutines.CoroutineContext.Key
  * }
  * ```
  *
- * On JVM, captures the thread name via ThreadLocal when no CallSign is in the
- * coroutine context. On JS/Native/WASM, relies on coroutine context only.
+ * On JVM, [Key.loggingName] falls back to the current thread name when no CallSign is
+ * present in the context, so log lines are still attributed. On JS/Native/WASM it relies
+ * on the coroutine context only and is null when no CallSign is present.
  */
 expect class CallSign(
     name: String,

--- a/hauler/src/jvmMain/kotlin/com/monkopedia/hauler/CallSign.kt
+++ b/hauler/src/jvmMain/kotlin/com/monkopedia/hauler/CallSign.kt
@@ -29,7 +29,7 @@ actual class CallSign actual constructor(
         val threadLoggingName: String?
             get() = currentName.get()
 
-        actual suspend fun loggingName(): String? = currentName.get() ?: coroutineContext[Key]?.name
+        actual suspend fun loggingName(): String? = currentName.get() ?: coroutineContext[Key]?.name ?: Thread.currentThread().name
     }
 
     actual override val key: Key

--- a/hauler/src/jvmTest/kotlin/com/monkopedia/hauler/LoggingNameJvmTest.kt
+++ b/hauler/src/jvmTest/kotlin/com/monkopedia/hauler/LoggingNameJvmTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.hauler
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * JVM-specific log-source attribution for [CallSign.loggingName] and the two ship paths.
+ *
+ * On JVM both the suspend [Hauler.ship] path (via [CallSign.loggingName]) and the
+ * non-suspend [AsyncHauler.ship] path (via the top-level [loggingName]) fall back to the
+ * current thread name when no [CallSign] is present, so the same log gets a thread name
+ * regardless of which entry point emitted it.
+ */
+class LoggingNameJvmTest {
+    @Test
+    fun loggingName_fallsBackToCurrentThreadName_whenNoCallSign() =
+        runTest {
+            assertEquals(Thread.currentThread().name, CallSign.loggingName())
+        }
+
+    @Test
+    fun loggingName_prefersCallSignName_overThreadName() =
+        runTest {
+            withContext(CallSign("request-handler")) {
+                assertEquals("request-handler", CallSign.loggingName())
+            }
+        }
+
+    @Test
+    fun shipPaths_agreeOnThreadNameAttribution_whenNoCallSign() =
+        runTest {
+            val collected = mutableListOf<Box>()
+            val hauler = Hauler { collected.add(it) }
+
+            hauler.ship(Level.INFO, "sync")
+            hauler.asAsync(this).ship(Level.INFO, "async")
+            withTimeout(2.seconds) {
+                while (collected.size < 2) delay(10)
+            }
+
+            // Before the fix the suspend path recorded threadName = null here while the
+            // async path recorded the thread name; both now attribute a thread name.
+            assertNotNull(collected.first { it.message == "sync" }.threadName)
+            assertNotNull(collected.first { it.message == "async" }.threadName)
+        }
+}


### PR DESCRIPTION
On JVM the two `ship` entry points attributed logs differently:

- **suspend path** — `Hauler.ship` → `CallSign.loggingName()`: `currentName.get() ?: coroutineContext[Key]?.name` — did **not** fall back to the thread name.
- **async path** — `AsyncHauler.ship` → top-level `loggingName()`: `CallSign.threadLoggingName ?: Thread.currentThread().name` — **did**.

So with no `CallSign` in context, `hauler.info(...)` recorded `threadName = null` while `asyncHauler.info(...)` recorded the real thread name — same logical call, different attribution.

**Change** (per @Monkopedia's approved direction): add the same `?: Thread.currentThread().name` fallback to the JVM `CallSign.loggingName()`, so both paths agree.

- Confined to the `jvmMain` `actual` body — the `expect fun loggingName()` and `CallSign.loggingName()` **signatures are unchanged**, so `apiCheck`/BCV is unaffected (no public API/ABI change).
- Purely **additive at runtime**: only fills the previously-`null` case; no existing non-null value changes.
- Adds `jvmTest` coverage (`LoggingNameJvmTest`): thread-name fallback, `CallSign`-name precedence over the fallback, and `Hauler.ship`/`AsyncHauler.ship` parity — the path was previously untested. Updates the `CallSign` KDoc.

Fixes #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)