### PR TITLE
Correct three false claims in MIGRATING.md (#32)

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -131,20 +131,30 @@ to the global `Garage` feed."
 ## `Flows.kt` extensions removed
 
 The `DeliveryService.deliveries(scope)` / `withDeliveryDay(scope)` /
-`dumpDeliveries(scope)` / `dumpWithDeliveryDay(scope)` extensions on
+`dumpDeliveries()` / `dumpWithDeliveryDay()` extensions on
 `DeliveryService` are gone — they were callback-flow shims around the old
 `register*` / `dump*` methods, which now return `Flow<T>` directly.
+
+Note the two `dump*` extensions took **no** parameters in 0.3.x; only the two
+live ones took a `scope`.
 
 | 0.3.x | 0.4.x |
 |---|---|
 | `service.deliveries(scope).collect { ... }` | `service.streamDeliveries().collect { ... }` |
 | `service.withDeliveryDay(scope).collect { ... }` | `service.streamDeliveriesPacked().unpack().collect { ... }` |
-| `service.dumpDeliveries(scope).collect { ... }` | `service.dumpDeliveries().collect { ... }` (now an interface method) |
-| `service.dumpWithDeliveryDay(scope).collect { ... }` | `service.dumpDeliveriesPacked().unpack().collect { ... }` |
+| `service.dumpDeliveries().collect { ... }` | `service.dumpDeliveries().collect { ... }` (same spelling — now an interface method, not an extension) |
+| `service.dumpWithDeliveryDay().collect { ... }` | `service.dumpDeliveriesPacked().unpack().collect { ... }` |
 
-The polling helpers `BasicDeliveryService.withPickup(...)` and
-`dumpWithPickup(...)` are unchanged — they still bridge polling
-`CustomerPickup` into a `Deliveries` flow.
+⚠️ `dumpDeliveries()` is the one call that looks unchanged and is not:
+the spelling is identical, but it moved from an extension function to an
+interface method. That is source-compatible and **binary**-incompatible —
+recompile rather than swapping the jar.
+
+The polling helpers `withPickup(...)` and `dumpWithPickup(...)` keep the same
+parameters, but their **receiver widened** from `DeliveryService` to
+`BasicDeliveryService`. Source-compatible, since `DeliveryService` extends
+`BasicDeliveryService` — but the JVM descriptor changed, so this too needs a
+recompile rather than a jar swap.
 
 ---
 
@@ -192,9 +202,12 @@ names changed in ksrpc 1.0:
 
 | 0.11.x | 1.0 |
 |---|---|
-| `HttpClient.asConnection(url, env).defaultChannel()` | `HttpClient.asHttpChannelClient(url, env).defaultChannel()` |
-| `HttpClient.asConnection(url, env)` (websocket) | `HttpClient.asWebsocketConnection(url, env)` |
+| HTTP `HttpClient.asConnection(url, env).defaultChannel()` | `HttpClient.asHttpChannelClient(url, env).defaultChannel()` |
+| Websocket `HttpClient.asWebsocketConnection(url, env)` | unchanged |
 | Sockets `(input to output).asConnection(env)` | unchanged |
+
+Only the **HTTP** entry point was renamed. `asWebsocketConnection` has had that
+name since 0.11.x and did not change in 1.0.
 
 See the [ksrpc 0.11.x → 1.0 migration guide](https://github.com/Monkopedia/ksrpc/blob/main/dokka/guides/migration-1.0.md)
 for the full ksrpc story.


### PR DESCRIPTION
Fixes #32.

`MIGRATING.md` is what a consumer reads while their build is broken. Three of its claims were false. Each was verified against the v0.3.0 tag, `origin/main`, and the local ksrpc clone's tags — not inferred.

### 1. A ksrpc rename that never happened (`:206`)

The table claimed `HttpClient.asConnection(url, env)` (websocket) → `asWebsocketConnection(url, env)` at 1.0.

`asWebsocketConnection` **already had that name in 0.11.x** — `ksrpc` `v0.11.0:…/WebsocketClientChannels.kt:32`, same at v0.11.2, and present in the committed ABI dump `v0.11.2:…/ksrpc-ktor-websocket-client.api:2`. There was never an `HttpClient.asConnection` in the websocket module; the "before" cell was invented, and a reader migrating websocket code went hunting for a call they never made.

The HTTP row directly above it **is** correct — `asConnection` → `asHttpChannelClient` is a real 1.0 rename (present at v0.11.2, absent at v1.1.4). Table now says which one moved.

### 2. A `scope` parameter the dump helpers never had (`:133-134`, `:142-143`)

At v0.3.0, `Flows.kt`:

```
:86   fun DeliveryService.dumpDeliveries(): Deliveries          // no parameters
:99   fun DeliveryService.dumpWithDeliveryDay(): Deliveries     // no parameters
```

`deliveries(closeScope)` at `:27` and `withDeliveryDay(closeScope)` at `:44` do take one, so those two rows were right.

Two consequences, and the second is worse. A reader greps their 0.3.x source for `dumpDeliveries(scope`, finds nothing, and concludes they're unaffected. And `service.dumpDeliveries()` was *already valid 0.3.x source*, so the row read as a no-op — when the actual change is extension function → interface method, which is source-compatible and **binary**-incompatible. Now called out explicitly, since it is the one call that looks unchanged and is not.

### 3. `withPickup` / `dumpWithPickup` were not "unchanged" (`:145-147`)

The **receiver widened**: v0.3.0 `Flows.kt:63,114` declare them on `DeliveryService`; 0.4.x `Flows.kt:27,34` on `BasicDeliveryService`. Parameters otherwise identical.

Source-compatible (`DeliveryService : BasicDeliveryService`), but `FlowsKt.withPickup`'s JVM descriptor changed — so "unchanged" is wrong for anyone swapping a jar without recompiling, a plausible audience for a migration guide.

For the record, since #10/PR #15 refactored these: **that refactor did not touch the signatures.** `git diff v0.4.1 v0.4.2 -- …/Flows.kt` shows both declaration headers byte-identical, only bodies extracted into `pollingDeliveries` (`Flows.kt:44`). The receiver drift is a 0.3.x→0.4.0 artifact.

---

### Scope and verification

**Documentation only.** One file, `MIGRATING.md`, +21/-8. No source, no API, no build files, no version pins. The JVM `apiDump` is untouched by construction.

**No build run for this PR** and I want that explicit rather than implied: nothing here can affect compilation, and the box is under a concurrency protocol after this morning's hard hang. CI will build it.

**Checked and found correct, so a reviewer needn't redo it:** the `Formatter` typealias citation (`Terminators.kt:28` — line number *and* signature exact, genuinely unchanged since v0.3.0); every "after" symbol in every mapping table exists with the claimed shape; `onDeliveryError` is defaulted `= {}` and genuinely server-side-only; the `attach`→`forwardTo` table; `registerDefault(warehouse, Shipper)`; the sockets row; the ksrpc 1.1.4 / Kotlin 2.4.10 versions (confirmed in the *published* POM); the semver-stability claim; and the migration-guide URL (HTTP 200).

**Label provenance, stated plainly:** #32 was moved to `agent-workable` by me earlier today under `triage-subagent.md:134-137`, not by the owner. The reasoning is recorded as a comment on the issue. Nothing here has owner approval — it is documentation correction with no statable owner question, and it is one revert away if that call was wrong.
