### PR TITLE
Correct the 0.4.2 release notes: four runtime deps left the published POM (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,15 @@ All notable changes to `hauler` are documented here. This project adheres to
   succeeds locally and in CI.
 
 _No source-level API changes in this release, and the JVM ABI dump (`hauler/api/hauler.api`)
-is unchanged from 0.4.1. Two caveats keep this short of a drop-in replacement: the published
-`hauler-jvm` POM dropped four runtime dependencies (see **Removed** above), and the
-native/JS/Wasm ABI was **not** verified across the Kotlin 2.4.0 → 2.4.10 bump — `klibApiCheck`
-is not currently an effective gate, so no klib baseline was compared. Recompiling against
-0.4.2 is safe; swapping the jar without re-resolving dependencies may not be._
+is unchanged from 0.4.1. Two caveats keep this short of a drop-in replacement._
+
+_First, the published `hauler-jvm` POM dropped four runtime dependencies (see **Removed**
+above). **Re-resolving your dependencies against 0.4.2 is what surfaces that loss** — if you
+were relying on any of the four transitively, they leave your runtime classpath at the point
+your build tool reads the new POM. A build that reuses an already-resolved classpath will not
+notice._
+
+_Second, the native/JS/Wasm ABI was **not** verified across the Kotlin 2.4.0 → 2.4.10 bump:
+`klibApiCheck` is not currently an effective gate, so no klib baseline was compared. The JVM
+surface is unchanged and checked; the other ten published artifacts are unverified rather
+than known-good._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ All notable changes to `hauler` are documented here. This project adheres to
   `AsyncHauler.ship` behavior — the two entry points now attribute logs consistently
   (#13).
 
+### Removed (may affect consumers)
+
+- Four dependencies that `hauler` did not use were dropped from the published
+  `hauler-jvm` POM (#6): `org.jetbrains.kotlin:kotlin-reflect`,
+  `org.slf4j:slf4j-api`, `com.github.ajalt.clikt:clikt-jvm`, and
+  `ch.qos.logback:logback-classic`.
+
+  They were declared `implementation` in `jvmMain`, which publishes as **runtime**
+  scope, so they were on the runtime classpath of every consumer. **If you were
+  resolving any of them transitively through `hauler`, declare them directly.**
+  `logback-classic` is the one most likely to bite: without it SLF4J has no
+  binding, which surfaces as `SLF4J: No providers were found` and silently
+  discarded log output rather than as a build failure.
+
+  A library should not have been exporting a logging backend, so the removal is
+  intentional and stays — but it is a consumer-visible change and the 0.4.2 notes
+  originally filed it as internal.
+
 ### Internal (no public API change)
 
 - Deduplicated `withPickup` / `dumpWithPickup` into a shared private polling helper (#10).
@@ -27,9 +45,10 @@ All notable changes to `hauler` are documented here. This project adheres to
   interning logic (#11).
 - `Garage.route` defaults its formatter to the `DefaultFormat` constant, consistent
   with the other `route` overloads (#12).
-- Removed vestigial `inline` from non-inlinable log helpers (#5) and unused JVM runtime
-  dependencies (#6); suppressed the expect/actual-classes Beta warning via
-  `-Xexpect-actual-classes` (#7).
+- Removed vestigial `inline` from non-inlinable log helpers (#5); suppressed the
+  expect/actual-classes Beta warning via `-Xexpect-actual-classes` (#7).
+  (The unused-JVM-dependency half of #6 is listed under Removed above — it changes
+  the published POM, so it is not internal.)
 
 ### Tooling
 
@@ -39,5 +58,9 @@ All notable changes to `hauler` are documented here. This project adheres to
   (Node 25) that the transitive `nanoid` npm dependency rejects, so the Wasm npm install
   succeeds locally and in CI.
 
-_No public API/ABI changes in this release; `hauler` 0.4.2 is a drop-in replacement for
-0.4.1 for consumers._
+_No source-level API changes in this release, and the JVM ABI dump (`hauler/api/hauler.api`)
+is unchanged from 0.4.1. Two caveats keep this short of a drop-in replacement: the published
+`hauler-jvm` POM dropped four runtime dependencies (see **Removed** above), and the
+native/JS/Wasm ABI was **not** verified across the Kotlin 2.4.0 → 2.4.10 bump — `klibApiCheck`
+is not currently an effective gate, so no klib baseline was compared. Recompiling against
+0.4.2 is safe; swapping the jar without re-resolving dependencies may not be._


### PR DESCRIPTION
Addresses **proposal 1 of #30 only.** Proposal 2 — *should the release procedure diff the published POM against the previous release?* — is a process decision that stays with the owner; #30 remains open for it.

### What was wrong

`CHANGELOG.md` 0.4.2 closed with:

> _No public API/ABI changes in this release; `hauler` 0.4.2 is a drop-in replacement for 0.4.1 for consumers._

Diffing the artifacts as they exist on Maven Central (both HTTP 200):

```
hauler-jvm-0.4.1.pom (4136 B)  ->  hauler-jvm-0.4.2.pom (3274 B)

REMOVED:
  org.jetbrains.kotlin:kotlin-reflect        (compile AND runtime entries)
  org.slf4j:slf4j-api:2.0.17                 runtime
  com.github.ajalt.clikt:clikt-jvm:5.1.0     runtime
  ch.qos.logback:logback-classic:1.5.32      runtime
```

They left with #6. Unused *by hauler* — but `implementation` in `jvmMain` publishes as **runtime** scope, so they were on every consumer's runtime classpath. A consumer resolving them transitively gets `NoClassDefFoundError`, and losing `logback-classic` means SLF4J has no binding: `SLF4J: No providers were found` and silently discarded output, rather than a build failure.

### What this changes

Documentation only. A new **Removed (may affect consumers)** section names the four coordinates and the remedy; the `#6` half moves out of *Internal (no public API change)*, where it did not belong; and the closing sentence now distinguishes what was verified from what was not.

That last part matters beyond the POM. The original sentence was unsupportable in a **second** way I want stated rather than quietly fixed: the JVM `apiDump` is genuinely unchanged, but the native/JS/Wasm ABI was never checked across the Kotlin 2.4.0 → 2.4.10 bump, because `klibApiCheck` is not an effective gate (#21). So "no ABI changes" rested on an instrument covering 1 of 11 platform artifacts.

**The removal itself is correct and stays.** A library exporting a logging backend transitively is bad practice; #6 fixed a real problem. Only the description was wrong.

### The case against merging this

Stated because a built thing creates pressure to accept it:

- **It edits the notes for a release that already shipped.** If you would rather 0.4.2's entry stand as a historical record and have this go in an `## Unreleased` note instead, that is a reasonable preference and this PR is the wrong shape for it.
- **It makes the release look worse.** "Not a drop-in replacement" is a real cost for a version already on Central, and you may judge the four dropped coordinates too obscure to be worth alarming anyone about.
- **The klib caveat is arguably #21's to state, not the CHANGELOG's** — I included it because the sentence it replaces made an ABI claim, but you could reasonably say a release note should not editorialise about gate coverage.

### Scope and verification

One file, `CHANGELOG.md`, +28/−5. No source, no API, no build files, no version pins.

**No build run**, deliberately: nothing here can affect compilation, and the box is under a concurrency protocol after this morning's hard hang. CI will build it.

**Label provenance:** #30 was moved to `agent-workable` by me today under `triage-subagent.md:134-137` — scoped, with reasoning recorded as a comment on the issue — not by the owner. Nothing here carries owner approval.
