### PR TITLE
Correct three KDoc claims that contradict the code (#31)

### DIFF
--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Conversions.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Conversions.kt
@@ -91,8 +91,13 @@ fun Flow<Palette>.unpack(): Deliveries =
  * Streaming packer that incrementally builds a [Palette] from individual [Box] emissions.
  *
  * Uses double-buffering: two sets of lists/maps are maintained so that [dumpLogs] can
- * return the current batch as a [Palette] and immediately swap to the alternate buffer,
- * avoiding allocation of new collections on each flush.
+ * swap to the alternate buffer immediately, rather than clearing and re-allocating the
+ * working collections on every flush.
+ *
+ * Note [dumpLogs] still copies via `toList()` when it builds the [Palette], and that copy
+ * is required for correctness — a returned [Palette] must not be mutated by subsequent
+ * packing. So the double-buffering saves re-allocating the *working* containers, not the
+ * per-flush allocation of the palette's own lists.
  *
  * Not thread-safe: callers must ensure sequential access (e.g. within a flow [transform]).
  */

--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Hauler.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Hauler.kt
@@ -114,9 +114,11 @@ interface AsyncHauler {
  * on JVM. On JS, Wasm and native it returns null; those platforms have no thread-local to
  * read and this is not a suspend function, so it cannot consult the coroutine context.
  *
- * Note this is the non-suspend path used by [AsyncHauler.ship]. The suspend
- * [CallSign.loggingName] additionally consults `coroutineContext`, so a [CallSign] installed
- * with `withContext` is visible there and not here.
+ * This is the non-suspend path used by [AsyncHauler.ship]. On JVM a [CallSign] installed
+ * with `withContext` IS visible here — [CallSign] is a `ThreadContextElement` and mirrors
+ * its name into a thread-local, which this reads. The suspend [CallSign.loggingName]
+ * additionally falls back to reading the element out of `coroutineContext`, which only
+ * differs when the element is present but the thread-local is not.
  */
 expect fun loggingName(): String?
 

--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Hauler.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Hauler.kt
@@ -108,7 +108,15 @@ interface AsyncHauler {
 
 /**
  * Get the current logging name for this execution context.
- * On JVM, returns the thread name. On other platforms, returns null.
+ *
+ * On JVM, returns the name of the [CallSign] installed on the current thread if there is
+ * one, and otherwise falls back to the current thread's name — so this never returns null
+ * on JVM. On JS, Wasm and native it returns null; those platforms have no thread-local to
+ * read and this is not a suspend function, so it cannot consult the coroutine context.
+ *
+ * Note this is the non-suspend path used by [AsyncHauler.ship]. The suspend
+ * [CallSign.loggingName] additionally consults `coroutineContext`, so a [CallSign] installed
+ * with `withContext` is visible there and not here.
  */
 expect fun loggingName(): String?
 

--- a/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Shipper.kt
+++ b/hauler/src/commonMain/kotlin/com/monkopedia/hauler/Shipper.kt
@@ -36,7 +36,11 @@ interface BasicShipper : RpcHostService {
 
 /**
  * Full [BasicShipper] plus observation via [deliveries]. Requires a bidirectional transport
- * (websocket, sockets, JNI) because [DeliveryService] accepts callback sub-services.
+ * (websocket, sockets, JNI) because [DeliveryService] returns `Flow<T>` streams.
+ *
+ * Returning a sub-service is not what forces bidi — [BasicShipper] returns [DropBox] and
+ * [LoadingDock] and is hostable on plain HTTP. It is the streaming returns that need a
+ * transport which can push.
  */
 @KsService
 interface Shipper :


### PR DESCRIPTION
Fixes #31. **Comment text only** — three KDoc blocks that assert things their own implementations contradict.

### 1. `Hauler.kt:109` — the unfinished half of #13

```
KDoc:  "On JVM, returns the thread name. On other platforms, returns null."
Impl:  actual fun loggingName(): String? =
           CallSign.threadLoggingName ?: Thread.currentThread().name
```

The CallSign name wins; the thread name is the *fallback*. Inside `withContext(CallSign("x"))` on the same thread this returns `"x"`.

**This is the twin of the KDoc that #13 / PR #17 corrected.** `git show --stat a315b2d` lists exactly three files — `commonMain/CallSign.kt`, `jvmMain/CallSign.kt`, and the new `LoggingNameJvmTest.kt`. `Hauler.kt` was never in that diff, so the reconciliation documented one entry point and left the other saying the opposite. I filed and drove #13, so this one is mine.

**~~The new text also states the asymmetry that genuinely remains: `loggingName()` is not `suspend`, so it cannot consult `coroutineContext` — a `CallSign` installed via `withContext` is visible to the suspend `CallSign.loggingName()` and not to this.~~ RETRACTED — this was false, and it was the reason cycle one returned REQUEST CHANGES.**

On JVM a `withContext`-installed `CallSign` **is** visible to the non-suspend path: `CallSign` is a `ThreadContextElement` (`jvmMain/CallSign.kt:24`) whose `updateThreadContext` (`:38-40`) mirrors the name into the thread-local that `loggingName()` reads. Note this description contradicted the paragraph directly above it, which correctly said the non-suspend function returns `"x"` inside `withContext(CallSign("x"))` — I wrote both and did not reconcile them.

The difference that actually remains is narrower: the suspend variant *additionally* falls back to reading the element out of `coroutineContext`, which diverges only when the element is present and the thread-local is not. Fixed in `56ab0849`.

### 2. `Conversions.kt:92` — stale, with a traceable cause

> _Uses double-buffering … avoiding allocation of new collections on each flush._

`dumpLogs()` calls `toList()` three times — **three fresh lists per flush.**

Provenance: the KDoc arrives in `e1f9111`; `8bd769b` ("Fix correctness issues and optimize hot paths") then changed `Palette(tagsList, …)` → `Palette(tagsList.toList(), …)`, and `git merge-base --is-ancestor e1f9111 8bd769b` is true. So it was accurate when written and invalidated by a later fix. The copy is **required** — `LogPackerTest.kt:112,134` assert an earlier palette is not corrupted by a later dump — so the comment moves, not the code. Reworded to say what the buffering actually saves: the working containers, not the palette's lists.

### 3. `Shipper.kt:38` — right conclusion, wrong reason

> _Requires a bidirectional transport … because `DeliveryService` accepts callback sub-services._

`DeliveryService` accepts **no** sub-service parameters — zero methods take a `@KsService` argument; its inputs are `Unit` and the `@Serializable` `WeighStation`. It is bidi because it **returns `Flow<T>`** (`DeliveryService.kt:57,61,65,69`).

And returning a sub-service does not require bidi at all, which this repo demonstrates internally: `BasicShipper` returns `DropBox`/`LoadingDock` and is hostable on plain HTTP.

### The case against merging

- **Nothing is broken by the current text at runtime**, and `dokka` is declared in the version catalog but applied in **zero** build scripts, so none of this KDoc is rendered or checked anywhere today. If your view is that KDoc accuracy only becomes worth paying for once docs are actually published, deferring this until dokka is wired up is coherent.
- **#2 is arguably a code smell disguised as a doc fix.** With `toList()` mandatory, the double-buffering buys little over just re-assigning fresh collections. I corrected the comment rather than simplifying the class, because removing the buffering is a behaviour-adjacent change and #31 is a documentation issue — but you may prefer the code change and no comment at all.

### Scope and verification

Three files, **all added lines are comments** — verified: 0 non-comment added lines in the diff. `hauler/api/hauler.api` is untouched by construction.

**No local build run**, deliberately: the box is under a concurrency protocol and comment-only edits cannot change compilation. Line lengths checked by hand — none of the added lines exceeds 100 chars; the three >100 lines in `Conversions.kt` (28, 32, 37) are pre-existing and already ktlint-clean. CI will compile and lint.

**Label provenance:** #31 was moved to `agent-workable` by me today under `triage-subagent.md:134-137`, not by the owner; reasoning is recorded as a comment on the issue.

