### PR TITLE
Actually test the hauler() factory entry points (#24)

### DIFF
--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/GarageTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/GarageTest.kt
@@ -129,14 +129,67 @@ class GarageTest {
 
     // --- hauler() factory ---
 
+    private class SampleComponent
+
     @Test
-    fun haulerFactory_setsName() =
+    fun haulerFactory_byName_setsLoggerNameAndRoutesToGarage() =
         runTest {
-            val collected = mutableListOf<Box>()
-            val base = Hauler { collected.add(it) }
-            val named = base.named("TestClass")
-            named.emit(box())
-            assertEquals("TestClass", collected[0].loggerName)
+            val result = mutableListOf<Box>()
+            val job =
+                launch {
+                    Garage.deliveries
+                        .take(1)
+                        .toList()
+                        .let { result.addAll(it) }
+                }
+            delay(50)
+
+            hauler("ByNameFactory").emit(box(message = "by name"))
+
+            withTimeout(2.seconds) { job.join() }
+            assertEquals(1, result.size)
+            assertEquals("ByNameFactory", result[0].loggerName)
+            assertEquals("by name", result[0].message)
+        }
+
+    @Test
+    fun haulerFactory_reifiedReceiver_usesSimpleName() =
+        runTest {
+            val result = mutableListOf<Box>()
+            val job =
+                launch {
+                    Garage.deliveries
+                        .take(1)
+                        .toList()
+                        .let { result.addAll(it) }
+                }
+            delay(50)
+
+            SampleComponent().hauler().emit(box(message = "from receiver"))
+
+            withTimeout(2.seconds) { job.join() }
+            assertEquals(1, result.size)
+            assertEquals("SampleComponent", result[0].loggerName)
+        }
+
+    @Test
+    fun createHauler_reified_usesSimpleName() =
+        runTest {
+            val result = mutableListOf<Box>()
+            val job =
+                launch {
+                    Garage.deliveries
+                        .take(1)
+                        .toList()
+                        .let { result.addAll(it) }
+                }
+            delay(50)
+
+            createHauler<SampleComponent>().emit(box(message = "from type"))
+
+            withTimeout(2.seconds) { job.join() }
+            assertEquals(1, result.size)
+            assertEquals("SampleComponent", result[0].loggerName)
         }
 
     // --- Garage global routing ---


### PR DESCRIPTION
**Addresses #24 — partially. Deliberately NOT closing it.**

#24 proposes four things. This PR does two:

| | |
|---|---|
| 1. make `haulerFactory_setsName` actually call `hauler()` | ✅ done |
| 2. `createHauler<T>()` / `T.hauler()` name derivation | ✅ done |
| 3. a `Deliveries.level` case | ❌ **not done** — 0 occurrences in `commonTest` |
| 4. `route` / `attach` coverage | ❌ **not done** — `.attach(` 0 occurrences; the three `route(` hits are the `Deliveries.route` extension in `TerminatorsTest`, not the Garage-scoped overload |

Originally this used a closing keyword, which would have **auto-closed the issue on merge and silently dropped half its scope.** Caught in review. The reference is now non-closing so #24 stays open for items 3 and 4.

`haulerFactory_setsName` sat under a `// --- hauler() factory ---` heading and **never called `hauler()`**. It was a verbatim re-run of `named_setsLoggerName` against `Hauler.named` — so that section comment was the only occurrence of `hauler(` anywhere in the test tree, and three public entry points had zero coverage.

### What replaces it

| test | exercises |
|---|---|
| `haulerFactory_byName_setsLoggerNameAndRoutesToGarage` | `hauler("ByNameFactory")` |
| `haulerFactory_reifiedReceiver_usesSimpleName` | `SampleComponent().hauler()` |
| `createHauler_reified_usesSimpleName` | `createHauler<SampleComponent>()` |

**Each asserts the log actually arrives on the global `Garage.deliveries` feed**, not merely that a logger name was set. That distinction is the substance of the change: `hauler(name)` is `Garage.rootHauler.named(name)`, so a test that only checks `loggerName` on a local `Hauler { }` — which is exactly what the old test did — **would still pass if the factory stopped routing through the Garage entirely.** These follow the collect-from-`Garage.deliveries` pattern the neighbouring `garage_*` tests already use.

### Verification

Run on a second machine under its build slot, JVM target:

```
BUILD SUCCESSFUL
jvmTest executed=184  failures=0
new tests present: haulerFactory_byName_setsLoggerNameAndRoutesToGarage[jvm]
                   haulerFactory_reifiedReceiver_usesSimpleName[jvm]
                   createHauler_reified_usesSimpleName[jvm]
```

**The count moved from 182 to 184 — exactly +2, which is what removing one test and adding three should do.** That arithmetic is the evidence the new tests were actually collected and executed, rather than merely compiled; a green build alone would not distinguish those. The three names are also read back individually from the JUnit XML rather than inferred from the total.

### What is not verified

**JVM only.** These live in `commonTest`, so they will also run on js, wasmJs and linuxX64 in PR CI — and, if #37 lands, on macOS, Windows and ARM too. **Two of the three depend on `T::class.simpleName`**, which is the most platform-sensitive thing here: it is not guaranteed to be identical across Kotlin targets for a private nested class. If `SampleComponent` resolves differently on a non-JVM target, those two will fail there. **I have not run them anywhere but the JVM**, and this PR's own CI is the check.

That is a real risk rather than a formality — I would rather it surface as a red job here than be discovered by a consumer.

### Provenance

#24 was moved to `agent-workable` **by me**, under `triage-subagent.md:134-137`, with the reasoning recorded as a comment on the issue. The owner has approved nothing. *"Do you want the test to exercise the function it is named after?"* is not a question that needed him.

