### PR TITLE
Fix two races in the delivery-path tests (#44) — both test bugs, verified against the configurations that produced them

### DIFF
--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/DeliveryServiceTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/DeliveryServiceTest.kt
@@ -235,21 +235,31 @@ class DeliveryServiceTest {
     @Test
     fun recurringCustomerPickup_collectsFromFlow() =
         runTest {
-            val (flow, service, scope) = createDeliveryService()
-            val pickup = service.recurringCustomerPickup()
+            // MUST run on a real dispatcher. createDeliveryService() builds a bare
+            // CoroutineScope(SupervisorJob()), which resolves to Dispatchers.Default, and
+            // CustomerPickupImpl launches its collector there -- on real threads. Left on
+            // runTest's virtual clock, the withTimeout below expires after five VIRTUAL
+            // seconds, which pass in a few thousand instantaneous delay(1) iterations, so
+            // the real-time budget the collector gets is only incidental thread-yield time.
+            // That failed 3 of 50 runs under CPU contention, and the runtime says so:
+            // "Timed out after 5s of _virtual_ (kotlinx.coroutines.test) time."
+            withContext(Dispatchers.Default) {
+                val (flow, service, scope) = createDeliveryService()
+                val pickup = service.recurringCustomerPickup()
 
-            flow.emit(box(message = "poll1"))
-            flow.emit(box(message = "poll2"))
+                flow.emit(box(message = "poll1"))
+                flow.emit(box(message = "poll2"))
 
-            val allBoxes = mutableListOf<Box>()
-            withTimeout(5.seconds) {
-                while (allBoxes.size < 2) {
-                    allBoxes.addAll(pickup.get().unpack())
-                    if (allBoxes.size < 2) delay(1)
+                val allBoxes = mutableListOf<Box>()
+                withTimeout(5.seconds) {
+                    while (allBoxes.size < 2) {
+                        allBoxes.addAll(pickup.get().unpack())
+                        if (allBoxes.size < 2) delay(1)
+                    }
                 }
+                assertEquals(2, allBoxes.size)
+                pickup.close()
+                scope.cancel()
             }
-            assertEquals(2, allBoxes.size)
-            pickup.close()
-            scope.cancel()
         }
 }

--- a/hauler/src/commonTest/kotlin/com/monkopedia/hauler/PipelineIntegrationTest.kt
+++ b/hauler/src/commonTest/kotlin/com/monkopedia/hauler/PipelineIntegrationTest.kt
@@ -20,6 +20,8 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -41,9 +43,28 @@ class PipelineIntegrationTest {
         threadName: String? = "main",
     ) = Box(level, loggerName, message, timestamp, threadName)
 
+    /**
+     * A list written by a collector coroutine and read by the test body.
+     *
+     * Every test here runs on [Dispatchers.Default], so those are genuinely different threads: a
+     * bare `mutableListOf` appended inside `collect { }` and iterated by an assertion produced a
+     * `ConcurrentModificationException` in 8 of 100 runs. Reads take a snapshot under the same
+     * lock the writer uses, so an assertion always sees a consistent list.
+     */
+    private class Collected<T> {
+        private val lock = Mutex()
+        private val items = mutableListOf<T>()
+
+        suspend fun add(item: T) {
+            lock.withLock { items.add(item) }
+        }
+
+        suspend fun snapshot(): List<T> = lock.withLock { items.toList() }
+    }
+
     private suspend fun awaitCondition(
         description: String = "",
-        check: () -> Boolean,
+        check: suspend () -> Boolean,
     ) {
         withTimeout(5.seconds) {
             while (!check()) delay(1)
@@ -58,7 +79,7 @@ class PipelineIntegrationTest {
                 val dropBox = warehouse.requestPickup()
                 val service = warehouse.deliveries()
 
-                val received = mutableListOf<Box>()
+                val received = Collected<Box>()
                 val collectJob =
                     launch {
                         service.streamDeliveries().collect { received.add(it) }
@@ -69,15 +90,16 @@ class PipelineIntegrationTest {
                 dropBox.log(box(level = Level.WARN, message = "second"))
                 dropBox.log(box(level = Level.ERROR, message = "third"))
 
-                awaitCondition { received.size >= 3 }
+                awaitCondition { received.snapshot().size >= 3 }
 
-                assertEquals(3, received.size)
-                assertEquals(Level.INFO, received[0].level)
-                assertEquals("first", received[0].message)
-                assertEquals(Level.WARN, received[1].level)
-                assertEquals("second", received[1].message)
-                assertEquals(Level.ERROR, received[2].level)
-                assertEquals("third", received[2].message)
+                assertEquals(3, received.snapshot().size)
+                val snap = received.snapshot()
+                assertEquals(Level.INFO, snap[0].level)
+                assertEquals("first", snap[0].message)
+                assertEquals(Level.WARN, snap[1].level)
+                assertEquals("second", snap[1].message)
+                assertEquals(Level.ERROR, snap[2].level)
+                assertEquals("third", snap[2].message)
                 collectJob.cancelAndJoin()
                 warehouse.close()
             }
@@ -91,7 +113,7 @@ class PipelineIntegrationTest {
                 val dock = warehouse.requestDockPickup()
                 val service = warehouse.deliveries()
 
-                val received = mutableListOf<Box>()
+                val received = Collected<Box>()
                 val collectJob =
                     launch {
                         service.streamDeliveries().collect { received.add(it) }
@@ -106,12 +128,13 @@ class PipelineIntegrationTest {
                     )
                 dock.bulkLog(boxes.pack())
 
-                awaitCondition { received.size >= 3 }
+                awaitCondition { received.snapshot().size >= 3 }
 
-                assertEquals(3, received.size)
-                assertEquals("bulk1", received[0].message)
-                assertEquals("bulk2", received[1].message)
-                assertEquals("bulk3", received[2].message)
+                assertEquals(3, received.snapshot().size)
+                val snap = received.snapshot()
+                assertEquals("bulk1", snap[0].message)
+                assertEquals("bulk2", snap[1].message)
+                assertEquals("bulk3", snap[2].message)
                 collectJob.cancelAndJoin()
                 warehouse.close()
             }
@@ -127,7 +150,7 @@ class PipelineIntegrationTest {
                 val dock = warehouse.requestDockPickup()
                 val service = warehouse.deliveries()
 
-                val received = mutableListOf<Box>()
+                val received = Collected<Box>()
                 val collectJob =
                     launch {
                         service.streamDeliveries().collect { received.add(it) }
@@ -143,12 +166,12 @@ class PipelineIntegrationTest {
                     ).pack(),
                 )
 
-                awaitCondition { received.size >= 4 }
+                awaitCondition { received.snapshot().size >= 4 }
 
-                assertEquals(4, received.size)
-                assertTrue(received.any { it.loggerName == "Source1" })
-                assertTrue(received.any { it.loggerName == "Source2" })
-                assertEquals(2, received.count { it.loggerName == "Source3" })
+                assertEquals(4, received.snapshot().size)
+                assertTrue(received.snapshot().any { it.loggerName == "Source1" })
+                assertTrue(received.snapshot().any { it.loggerName == "Source2" })
+                assertEquals(2, received.snapshot().count { it.loggerName == "Source3" })
                 collectJob.cancelAndJoin()
                 warehouse.close()
             }
@@ -163,7 +186,7 @@ class PipelineIntegrationTest {
                 val service = warehouse.deliveries()
                 val filtered = service.weighIn(LevelFilter(LevelMatchMode.GT, Level.INFO))
 
-                val received = mutableListOf<Box>()
+                val received = Collected<Box>()
                 val collectJob =
                     launch {
                         filtered.streamDeliveries().collect { received.add(it) }
@@ -175,11 +198,12 @@ class PipelineIntegrationTest {
                 dropBox.log(box(level = Level.WARN, message = "keep-warn"))
                 dropBox.log(box(level = Level.ERROR, message = "keep-error"))
 
-                awaitCondition { received.size >= 2 }
+                awaitCondition { received.snapshot().size >= 2 }
 
-                assertEquals(2, received.size)
-                assertEquals("keep-warn", received[0].message)
-                assertEquals("keep-error", received[1].message)
+                assertEquals(2, received.snapshot().size)
+                val snap = received.snapshot()
+                assertEquals("keep-warn", snap[0].message)
+                assertEquals("keep-error", snap[1].message)
                 collectJob.cancelAndJoin()
                 warehouse.close()
             }
@@ -198,7 +222,7 @@ class PipelineIntegrationTest {
                 val dropBox = warehouse.requestPickup()
                 val service = warehouse.deliveries()
 
-                val received = mutableListOf<Palette>()
+                val received = Collected<Palette>()
                 val collectJob =
                     launch {
                         service.streamDeliveriesPacked().collect { received.add(it) }
@@ -209,11 +233,11 @@ class PipelineIntegrationTest {
                 dropBox.log(box(message = "batch-b"))
 
                 awaitCondition("batched delivery received") {
-                    val allBoxes = received.flatMap { it.unpack() }
+                    val allBoxes = received.snapshot().flatMap { it.unpack() }
                     allBoxes.size >= 2
                 }
 
-                val allBoxes = received.flatMap { it.unpack() }
+                val allBoxes = received.snapshot().flatMap { it.unpack() }
                 assertTrue(allBoxes.any { it.message == "batch-a" })
                 assertTrue(allBoxes.any { it.message == "batch-b" })
                 collectJob.cancelAndJoin()
@@ -229,7 +253,7 @@ class PipelineIntegrationTest {
                 val dropBox = warehouse.requestPickup()
                 val service = warehouse.deliveries()
 
-                val received = mutableListOf<Box>()
+                val received = Collected<Box>()
                 val collectJob =
                     launch {
                         service.streamDeliveries().collect { received.add(it) }
@@ -239,10 +263,11 @@ class PipelineIntegrationTest {
                 val meta = mapOf("requestId" to "abc-123", "userId" to "42")
                 dropBox.log(box(message = "with-meta").copy(metadata = meta))
 
-                awaitCondition { received.isNotEmpty() }
+                awaitCondition { received.snapshot().isNotEmpty() }
 
-                assertEquals(1, received.size)
-                assertEquals(meta, received[0].metadata)
+                assertEquals(1, received.snapshot().size)
+                val snap = received.snapshot()
+                assertEquals(meta, snap[0].metadata)
                 collectJob.cancelAndJoin()
                 warehouse.close()
             }
@@ -266,7 +291,7 @@ class PipelineIntegrationTest {
                 assertEquals("historical", dumped[0].message)
 
                 // Subscribe — SharedFlow replay means subscriber also gets cached events
-                val live = mutableListOf<Box>()
+                val live = Collected<Box>()
                 val collectJob =
                     launch {
                         service.streamDeliveries().collect { live.add(it) }
@@ -276,12 +301,12 @@ class PipelineIntegrationTest {
                 dropBox.log(box(message = "live"))
 
                 awaitCondition("live delivery received") {
-                    live.any { it.message == "live" }
+                    live.snapshot().any { it.message == "live" }
                 }
 
                 // Subscriber receives replayed "historical" + new "live"
-                assertTrue(live.any { it.message == "historical" })
-                assertTrue(live.any { it.message == "live" })
+                assertTrue(live.snapshot().any { it.message == "historical" })
+                assertTrue(live.snapshot().any { it.message == "live" })
                 collectJob.cancelAndJoin()
                 warehouse.close()
             }


### PR DESCRIPTION
Closes #44

Both flakes in #44 are **bugs in the tests, not the library**. No library code changes here. They have **opposite trigger conditions**, which is why no single repetition strategy found them — and why my own first attempt, 15 fresh Gradle runs on an idle 16-core box, found neither.

## Reproduction matrix, before

```
                                          pipeline_replay   recurringCustomerPickup
A  full suite,      25x, 16 cores               1/25                 0/25
B  Pipeline alone, 100x, 16 cores               8/100                 -
C  DeliveryService alone, 100x, 16 cores          -                  0/100
D  target alone,   100x, PINNED to 1 core         -                  0/100
E  Pipeline alone, 100x, PINNED to 1 core       0/100                  -
F  DeliveryService, 50x, PINNED to 1 core         -                   3/50
```

Row **E** is the load-bearing one: pinning to a single core takes `pipeline_replayAndLiveDelivery` from 8% to zero. That is not "the flake is rare" — a failure that *needs* parallelism and disappears without it names its own mechanism, and the stack trace then confirms it independently.

## Mechanism 1 — data race on the collector list

```
kotlin.ConcurrentModificationException
  at kotlin.collections.ArrayList.Itr.next
  at PipelineIntegrationTest ... awaitCondition
```

Every test in `PipelineIntegrationTest` runs on `Dispatchers.Default`, so `collect { live.add(it) }` appends on one thread while `live.any { }` iterates on another.

Fixed **class-wide rather than at the throwing line**. The other six tests have the identical race and only avoid `ConcurrentModificationException` because they read `.size` instead of iterating — patching one line would have left six latent copies. Reads now take a snapshot under the writer's lock, and `awaitCondition` takes a `suspend` predicate so the snapshot can be awaited.

## Mechanism 2 — virtual time racing real threads

The runtime names this one itself:

```
TimeoutCancellationException: Timed out after 5s of _virtual_ (kotlinx.coroutines.test) time.
To use the real time, wrap 'withTimeout' in 'withContext(Dispatchers.Default.limitedParallelism(1))'
```

`createDeliveryService()` builds a bare `CoroutineScope(SupervisorJob())` — no dispatcher, so `Dispatchers.Default` — and `CustomerPickupImpl` launches its collector there, on real threads. The test body stayed on `runTest`'s virtual clock, so `withTimeout(5.seconds)` expired after five *virtual* seconds: a few thousand instantaneous `delay(1)` iterations, leaving the collector only incidental thread-yield time. Contention eats that.

**This is not a timeout bump.** `withContext(Dispatchers.Default)` restores a real-time budget, so the test stops being flaky because it stops being on the virtual clock. And it is not a new idea here: **5 of the 8 tests in that class already do it, and the flaky one was among the 3 that don't.** The convention existed; the fix is making the test follow it.

## Verification

Same configurations, same `n`, against a binary **confirmed relinked**:

```
B  Pipeline alone, 100x, 16 cores       8/100  ->  0/100
F  DeliveryServiceTest, 50x, 1 core      3/50  ->  0/50
A  full suite, 25x, one process          1/25  ->  0/25
```

My **first** verification attempt was invalid and I am recording it rather than quietly redoing it: compilation failed, so the reproducers ran the *stale* binary and printed 9/100 and 3/50 — numbers from unfixed code that looked exactly like a real result. The harness now aborts on a failed build **and** on an unchanged binary mtime, because a green build that relinks nothing produces the same false confidence.

Separately, my failure counter grepped `FAILED` while the Kotlin/Native `SIMPLE` logger writes `Failed:`, so it reported `failures: 0` for an exit-code-1 run. The only thing that caught it was the exit code disagreeing with my own summary line. Counts above use the correct marker.

## What this does not establish

- **The `[macosArm64]` instance is consistent with mechanism 1 but not measured.** macOS runners are multi-core, which fits, but I have no macOS host and did not run it there. Anyone reading this alongside the open Apple-target coverage question (#22 / #37) should not take it as an Apple result.
- **Rate on a 4-core CI runner is not measured** — only 16-core and 1-core. The CI failure was configuration F, which reproduces at 6%.
- Five tests in `GarageTest` subscribe to the process-wide `Garage.deliveries` and depend on a `delay(50)` race against the silent-drop behaviour in #45. That is a real fragility and **not** what was failing here; it belongs with #45, not this PR.