### PR TITLE
SPIKE — DO NOT MERGE: prove the guard's RED paths on macOS 3.2, Windows and ubuntu (#53)

### DIFF
--- a/.github/selftest-assert-guard.sh
+++ b/.github/selftest-assert-guard.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# TEMPORARY — belongs to the throwaway PR for hauler #53. Do not merge.
+#
+# Drives every RED branch of assert-tests-executed.sh on the runner it is
+# invoked from, and asserts the emitted MESSAGE, not the exit code.
+#
+# ⚠️ WHY THE MESSAGE. A red job cannot distinguish "the branch fired correctly"
+# from "the interpreter died one line earlier". Both are red. On macOS that is
+# not hypothetical: /bin/bash is 3.2.57, and expanding an empty array under
+# `set -u` is an "unbound variable" error before bash 4.4 — which would abort
+# one line ABOVE the message the branch exists to print.
+set -uo pipefail
+
+G=./.github/assert-tests-executed.sh
+D=hauler/build/test-results/zzSelfTest
+fails=0
+
+echo "interpreter: ${BASH_VERSION:-<not bash>}   ($(command -v bash))"
+bash --version | head -1
+echo
+
+expect() {                       # expect <label> <want-rc> <want-substring>
+  local label=$1 want_rc=$2 want=$3 out rc
+  out=$("$G" zzSelfTest 2>&1); rc=$?
+  if [ "$rc" -ne "$want_rc" ]; then
+    echo "FAIL  $label: rc=$rc want=$want_rc"; echo "      out: $out"; fails=$((fails + 1)); return
+  fi
+  case "$out" in
+    *"$want"*) echo "ok    $label  (rc=$rc)  <- $want" ;;
+    *) echo "FAIL  $label: rc correct but WRONG MESSAGE"; echo "      want substring: $want"; echo "      got: $out"; fails=$((fails + 1)) ;;
+  esac
+}
+
+rm -rf "$D"
+# 1. no results directory
+out=$("$G" zzSelfTest 2>&1); rc=$?
+case "$rc:$out" in
+  1:*"cannot determine whether it ran"*) echo "ok    no-directory  (rc=1)" ;;
+  *) echo "FAIL  no-directory: rc=$rc out=$out"; fails=$((fails + 1)) ;;
+esac
+
+# 2. directory, no XML  <- the bash 3.2 empty-glob branch
+mkdir -p "$D"
+expect "no-XML" 1 "did not report at all"
+
+# 3. XML present, nothing parseable
+printf '<testsuite name="x"/>\n' > "$D/a.xml"
+expect "parser-failure" 1 "NONE parseable"
+
+# 4. partial parse
+printf '<testsuite name="y" tests="5"/>\n' > "$D/b.xml"
+expect "partial-parse" 1 "PARTIAL PARSE"
+
+# 5. implausibly large
+rm -f "$D/a.xml"; printf '<testsuite name="y" tests="9999999999"/>\n' > "$D/b.xml"
+expect "oversize" 1 "implausibly large"
+
+# 6. zero tests
+printf '<testsuite name="y" tests="0"/>\n' > "$D/b.xml"
+expect "zero-tests" 1 "ZERO tests executed"
+
+# 7. octal-looking count must not wrap or abort
+printf '<testsuite name="y" tests="017"/>\n' > "$D/b.xml"
+expect "leading-zero" 0 "17 tests executed"
+
+# 8. green
+printf '<testsuite name="y" tests="42"/>\n' > "$D/b.xml"
+expect "green" 0 "42 tests executed"
+
+# 9. no arguments
+out=$("$G" 2>&1); rc=$?
+case "$rc:$out" in
+  1:*"nothing was asserted"*) echo "ok    no-args  (rc=1)" ;;
+  *) echo "FAIL  no-args: rc=$rc out=$out"; fails=$((fails + 1)) ;;
+esac
+
+rm -rf "$D"
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "::error::guard self-test: $fails state(s) wrong on this runner."
+  exit 1
+fi
+echo "guard self-test: all states correct on this runner"

--- a/.github/selftest-assert-guard.sh
+++ b/.github/selftest-assert-guard.sh
@@ -14,6 +14,14 @@ set -uo pipefail
 G=./.github/assert-tests-executed.sh
 D=hauler/build/test-results/zzSelfTest
 fails=0
+observed=0
+EXPECTED_STATES=9
+
+# ⚠️ COUNT WHAT WAS DRIVEN, DO NOT INFER IT. A state that never ran and a state
+# that ran and printed the right message produce the same output unless the
+# total is asserted. That is the `${total:-0}` defect one level up, inside the
+# instrument built to catch it — so this script refuses to report success
+# without having observed all EXPECTED_STATES.
 
 echo "interpreter: ${BASH_VERSION:-<not bash>}   ($(command -v bash))"
 bash --version | head -1
@@ -26,7 +34,7 @@ expect() {                       # expect <label> <want-rc> <want-substring>
     echo "FAIL  $label: rc=$rc want=$want_rc"; echo "      out: $out"; fails=$((fails + 1)); return
   fi
   case "$out" in
-    *"$want"*) echo "ok    $label  (rc=$rc)  <- $want" ;;
+    *"$want"*) observed=$((observed + 1)); echo "ok    $label  (rc=$rc)  <- $want" ;;
     *) echo "FAIL  $label: rc correct but WRONG MESSAGE"; echo "      want substring: $want"; echo "      got: $out"; fails=$((fails + 1)) ;;
   esac
 }
@@ -35,7 +43,7 @@ rm -rf "$D"
 # 1. no results directory
 out=$("$G" zzSelfTest 2>&1); rc=$?
 case "$rc:$out" in
-  1:*"cannot determine whether it ran"*) echo "ok    no-directory  (rc=1)" ;;
+  1:*"cannot determine whether it ran"*) observed=$((observed + 1)); echo "ok    no-directory  (rc=1)" ;;
   *) echo "FAIL  no-directory: rc=$rc out=$out"; fails=$((fails + 1)) ;;
 esac
 
@@ -70,14 +78,20 @@ expect "green" 0 "42 tests executed"
 # 9. no arguments
 out=$("$G" 2>&1); rc=$?
 case "$rc:$out" in
-  1:*"nothing was asserted"*) echo "ok    no-args  (rc=1)" ;;
+  1:*"nothing was asserted"*) observed=$((observed + 1)); echo "ok    no-args  (rc=1)" ;;
   *) echo "FAIL  no-args: rc=$rc out=$out"; fails=$((fails + 1)) ;;
 esac
 
 rm -rf "$D"
 echo
+echo "observed $observed of $EXPECTED_STATES states"
 if [ "$fails" -ne 0 ]; then
   echo "::error::guard self-test: $fails state(s) wrong on this runner."
   exit 1
 fi
-echo "guard self-test: all states correct on this runner"
+if [ "$observed" -ne "$EXPECTED_STATES" ]; then
+  echo "::error::guard self-test: only $observed of $EXPECTED_STATES states were OBSERVED."
+  echo "::error::Coverage is not silence. A state that did not run is not a state that passed."
+  exit 1
+fi
+echo "guard self-test: all $observed states observed and correct on this runner"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,12 @@ jobs:
       - name: Assemble, test, apiCheck, ktlint
         run: ./gradlew :hauler:assemble :hauler:check ktlintCheck -x klibApiCheck
 
+      # TEMPORARY (#53 spike, do not merge): prove the guard's RED branches
+      # on THIS runner's interpreter, asserting the message not the exit code.
+      - name: Guard self-test (spike)
+        if: always()
+        run: ./.github/selftest-assert-guard.sh
+
       - name: Assert the ubuntu suites executed
         if: always()
         run: ./.github/assert-tests-executed.sh jvmTest jsNodeTest wasmJsNodeTest linuxX64Test
@@ -98,6 +104,12 @@ jobs:
         # ⚠️ --dry-run: prints SKIPPED for EVERY task including ones that really
         # ran. Readable task list, inert as evidence of execution. Do not cite it.
 
+      # TEMPORARY (#53 spike, do not merge): prove the guard's RED branches
+      # on THIS runner's interpreter, asserting the message not the exit code.
+      - name: Guard self-test (spike)
+        if: always()
+        run: ./.github/selftest-assert-guard.sh
+
       - name: Assert the Apple suites executed
         if: always()
         run: ./.github/assert-tests-executed.sh macosArm64Test iosSimulatorArm64Test
@@ -126,6 +138,13 @@ jobs:
         run: rm -rf hauler/build/test-results
       - name: mingwX64 tests
         run: ./gradlew :hauler:mingwX64Test --console=plain
+
+      # TEMPORARY (#53 spike, do not merge): prove the guard's RED branches
+      # on THIS runner's interpreter, asserting the message not the exit code.
+      - name: Guard self-test (spike)
+        if: always()
+        shell: bash
+        run: ./.github/selftest-assert-guard.sh
 
       - name: Assert the mingwX64 suite executed
         if: always()


### PR DESCRIPTION
**Throwaway spike for #53. Draft, targets `ci/execute-untested-targets`, and is to be closed unmerged — the deliverable is the run, not the diff.**

## The premise of #53 was wrong, which is what makes this cheap

#53 said nobody who had looked had a bash 3.2 to test on. **False.** The `apple` leg is `macos-latest`, and `/bin/bash` there is **3.2.57**. Every PR has already been executing `assert-tests-executed.sh` on the interpreter I called untestable — the empty-array branch simply never fired, because the happy path was always taken.

So this is not "acquire a macOS environment." It is "drive the red branches on the leg that already exists."

Credit: raised by ksrpc's triage after it found the same wrong premise in its own repo — its agent had been repeating *"this machine is not a Mac"* for two weeks. It found it by **checking a briefing rather than accepting one.**

## What the spike asserts

`.github/selftest-assert-guard.sh` drives all nine states of the guard on ubuntu, macOS and Windows and **asserts the emitted MESSAGE, not the exit code**:

```
no-directory · no-XML · parser-failure · partial-parse · oversize
zero-tests · leading-zero · green · no-args
```

**Why the message and not the colour:** a red job cannot distinguish *the branch firing correctly* from *the interpreter dying one line earlier*. On macOS that is concrete — expanding an empty array under `set -u` is an `unbound variable` error before bash 4.4, which would abort one line **above** the message the branch exists to print. Both outcomes are red. Only the text tells them apart.

`no-XML` is the branch that would have hit it. The array and `nullglob` were already removed from the guard for exactly this reason, so **the expected result is a clean pass that proves the removal was sufficient** — currently "I removed it" is unverified in the environment that motivated the removal.

## It also settles a question I could not answer by reading

The guard's shebang is `#!/usr/bin/env bash`, so the interpreter is the first `bash` on `PATH`, **not necessarily `/bin/bash`**. Whether that is 3.2.57 or a newer bash on GitHub's macOS image, I do not know. The self-test prints `$BASH_VERSION` and `bash --version` from inside the script, so the run answers it. **Reasoning about it is what produced five defects in this file already.**

Local result (ubuntu, bash 5.3.15) — all nine states correct.

## ⚠️ Not used, deliberately

`publish.yaml` is also `macos-latest` and also `workflow_dispatch`-able. **It is not a macOS testbed**: dispatching it publishes to Maven Central from whatever ref it is given, which is precisely the defect filed as #50. The macOS access used here is the ordinary PR-triggered `apple` job.

## Disposition

Read the three job logs, record the interpreter versions and any wrong-message state on #53, then **close this unmerged**. Nothing here belongs on `main`.