### PR TITLE
Keep the guard's refusal self-test — proven on ubuntu/macOS/Windows (#55). Merge AFTER #37.

### DIFF
--- a/.github/selftest_assert_guard.py
+++ b/.github/selftest_assert_guard.py
@@ -163,24 +163,29 @@ def main() -> int:
                 guard.write_text(
                     src.replace(marker, marker + '    raise RuntimeError("injected")\n'),
                     encoding="utf-8")
+            # BYTES, decoded here rather than by subprocess. With text=True the
+            # decode happens on subprocess's reader THREAD: a UnicodeDecodeError
+            # there kills the thread, leaves stdout as None, and surfaces as
+            # "TypeError: NoneType + str" -- a headline that says nothing about
+            # encoding, four lines below the real finding. Decoding at the call
+            # site turns the same event into a reportable result.
+            p = subprocess.run([sys.executable, str(guard), *args],
+                               cwd=root, capture_output=True)
+            rc = p.returncode
+            raw = p.stdout + p.stderr
+            mojibake = None
             try:
-                p = subprocess.run(
-                    [sys.executable, str(guard), *args],
-                    cwd=root, capture_output=True, text=True,
-                    # STRICT, not "replace". The guard emits a non-ASCII em
-                    # dash; a runner whose stdout encoding mangles it (Windows
-                    # cp1252 encodes U+2014 as 0x97) produced bytes that
-                    # "replace" silently turned into U+FFFD while every ASCII
-                    # assertion still matched -- green, on the exact scenario
-                    # this file exists to test. Strict raises instead.
-                    encoding="utf-8", errors="strict",
-                )
-                out = p.stdout + p.stderr
-                rc = p.returncode
+                out = raw.decode("utf-8", "strict")
             except UnicodeDecodeError as e:
-                out, rc = f"UNDECODABLE OUTPUT: {e}", -1
+                mojibake = e
+                out = raw.decode("utf-8", "replace")
         driven.append(c["name"])
         problems = []
+        if mojibake is not None:
+            problems.append(
+                f"guard emitted non-UTF-8 output ({mojibake.reason} at byte "
+                f"{mojibake.start}) -- its messages are MANGLED on this runner, "
+                "which is silent in a green run")
         if rc != c["rc"]:
             problems.append(f"exit {rc}, expected {c['rc']}")
         for want in c["expect"]:

--- a/.github/selftest_assert_guard.py
+++ b/.github/selftest_assert_guard.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Drive every refusal branch of assert_tests_executed.py and assert its MESSAGE.
+
+WHY THIS EXISTS (hauler #55). A red job cannot distinguish the branch firing
+correctly from the interpreter, the path layer or the encoder dying one line
+earlier. Both are red. Both look like the guard working. This repo has shipped
+that exact confusion four times -- right colour, wrong cause -- so the only
+useful assertion is on the TEXT the branch itself prints.
+
+WHY IT RUNS ON THREE RUNNERS. The happy path is proven on ubuntu, macOS and
+Windows (matching counts on all five legs). The refusal paths are proven on
+ubuntu only. They are the branches that touch the FILESYSTEM, and Windows is
+where that differs: Git Bash hands out /c/Users/... style paths and Python
+resolves them through a different layer. `no results directory` in particular
+could refuse for the wrong reason and look like a correct refusal.
+
+It also asserts NO case reports a crash. The guard's own messages contain a
+non-ASCII em dash; a console codepage that cannot encode it would raise inside
+the print, hit the top-level handler, and still exit 1 -- a correct-looking red
+carrying the wrong text. That is a Windows-shaped failure and it is invisible to
+an exit-code check.
+"""
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+GUARD = Path(__file__).resolve().parent / "assert_tests_executed.py"
+RESULTS = Path("hauler/build/test-results")
+
+SUITE_OK = '<testsuite name="s" tests="3" failures="0"></testsuite>'
+SUITE_ZERO = '<testsuite name="s" tests="0" failures="0"></testsuite>'
+SUITE_TORN = '<testsuite name="s" tests="3"'  # truncated: unparseable
+SUITE_NOATTR = '<testsuite name="s" failures="0"></testsuite>'
+
+
+def write(root: Path, task: str, files: dict) -> None:
+    d = root / RESULTS / task
+    d.mkdir(parents=True, exist_ok=True)
+    for name, body in files.items():
+        (d / name).write_text(body, encoding="utf-8")
+
+
+CASES = []
+
+
+def case(name, expect, rc=1):
+    def deco(fn):
+        CASES.append({"name": name, "expect": expect, "rc": rc, "setup": fn})
+        return fn
+    return deco
+
+
+@case("no results directory", ["no results directory at", "NOT a pass"])
+def _(root):
+    (root / RESULTS).mkdir(parents=True, exist_ok=True)
+    return ["ghostTask"]
+
+
+@case("directory but no XML", ["contains NO XML", "did not report at all"])
+def _(root):
+    (root / RESULTS / "emptyTask").mkdir(parents=True, exist_ok=True)
+    return ["emptyTask"]
+
+
+@case("all XML unparseable", ["NONE parseable", "PARSER failure"])
+def _(root):
+    write(root, "tornTask", {"a.xml": SUITE_TORN, "b.xml": SUITE_TORN})
+    return ["tornTask"]
+
+
+@case("partial parse", ["only 1 of 2", "PARTIAL PARSE"])
+def _(root):
+    write(root, "partialTask", {"a.xml": SUITE_OK, "b.xml": SUITE_TORN})
+    return ["partialTask"]
+
+
+@case("tests= present but not an integer", ["is not an integer"])
+def _(root):
+    write(root, "bogusTask", {"a.xml": '<testsuite name="s" tests="0x10"></testsuite>'})
+    return ["bogusTask"]
+
+
+@case("no tests= attribute at all", ["no <testsuite tests=...> attribute"])
+def _(root):
+    write(root, "noattrTask", {"a.xml": SUITE_NOATTR})
+    return ["noattrTask"]
+
+
+@case("parsed cleanly, zero tests", ["report ZERO tests executed"])
+def _(root):
+    write(root, "zeroTask", {"a.xml": SUITE_ZERO})
+    return ["zeroTask"]
+
+
+@case("no task names given", ["called with no task names", "empty set is not a pass"])
+def _(root):
+    return []
+
+
+@case("good task THEN phantom -- the v3 unwind shape",
+      ["3 tests executed", "no results directory at"])
+def _(root):
+    write(root, "goodTask", {"a.xml": SUITE_OK})
+    return ["goodTask", "phantomTask"]
+
+
+@case("happy path", ["3 tests executed"], rc=0)
+def _(root):
+    write(root, "goodTask", {"a.xml": SUITE_OK})
+    return ["goodTask"]
+
+
+def main() -> int:
+    print(f"guard under test: {GUARD}")
+    print(f"python: {sys.version.split()[0]}  platform: {sys.platform}")
+    if not GUARD.is_file():
+        print(f"::error::self-test cannot find the guard at {GUARD}")
+        return 1
+
+    driven, failures = 0, []
+    for c in CASES:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            args = c["setup"](root)
+            p = subprocess.run(
+                [sys.executable, str(GUARD), *args],
+                cwd=root, capture_output=True, text=True,
+                encoding="utf-8", errors="replace",
+            )
+        out = p.stdout + p.stderr
+        driven += 1
+        problems = []
+        if p.returncode != c["rc"]:
+            problems.append(f"exit {p.returncode}, expected {c['rc']}")
+        for want in c["expect"]:
+            if want not in out:
+                problems.append(f"missing text: {want!r}")
+        # A red for the WRONG reason is the failure this file exists to catch.
+        if "crashed:" in out:
+            problems.append("guard CRASHED -- red for the wrong reason")
+        if problems:
+            failures.append((c["name"], problems, out.strip()))
+            print(f"FAIL  {c['name']}")
+            for pr in problems:
+                print(f"        {pr}")
+            print("      --- actual output ---")
+            for line in out.strip().splitlines():
+                print(f"      | {line}")
+        else:
+            print(f"ok    {c['name']}  (exit {p.returncode}, message asserted)")
+
+    # A state that never ran and a state that ran correctly are otherwise
+    # indistinguishable in this output. Assert the denominator.
+    print(f"\n{driven} of {len(CASES)} states driven; {len(failures)} failed.")
+    if driven != len(CASES):
+        print(f"::error::self-test drove only {driven} of {len(CASES)} states.")
+        print("::error::States not driven are NOT states that passed.")
+        return 1
+    if failures:
+        print(f"::error::{len(failures)} refusal branch(es) did not behave as specified "
+              f"on {sys.platform}.")
+        return 1
+    print(f"All {len(CASES)} states behaved as specified on {sys.platform}.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        print(f"::error::selftest_assert_guard.py crashed: {type(e).__name__}: {e}")
+        print("::error::A crash is not a pass.")
+        sys.exit(1)

--- a/.github/selftest_assert_guard.py
+++ b/.github/selftest_assert_guard.py
@@ -54,9 +54,14 @@ SUITES_ONE_NOATTR = ('<testsuites><testsuite name="a" tests="4"/>'
 SUITE_SKIPPED_SOME = '<testsuite name="s" tests="181" skipped="3"/>'
 SUITE_SKIPPED_ALL = '<testsuite name="s" tests="5" skipped="5"/>'
 SUITE_NEGATIVE = '<testsuite name="s" tests="-1"/>'
+# The last two refusal branches with no case. Both let a broken guard exit 0:
+# with `skipped > ran` removed the guard printed "-5 tests executed" and passed,
+# and a NEGATIVE total is the specific hazard _count's own docstring records.
+SUITE_SKIP_EXCEEDS = '<testsuite name="s" tests="5" skipped="10"/>'
+SUITE_IMPLAUSIBLE = '<testsuite name="s" tests="99999999999"/>'
 
 # A literal, so that deleting a case is a RED rather than a smaller denominator.
-EXPECTED_STATES = 16
+EXPECTED_STATES = 18
 
 
 def write(root: Path, task: str, files: dict) -> None:
@@ -129,7 +134,7 @@ def _(root):
 
 
 @case("phantom THEN good task -- the v3 unwind shape",
-      ["no results directory at", "3 tests executed"])
+      ["no results directory at", " 3 tests executed"])
 def _(root):
     write(root, "goodTask", {"a.xml": SUITE_OK})
     # FAILING TASK FIRST, deliberately. With the good task first, a guard that
@@ -159,14 +164,14 @@ def _(root):
 
 
 @case("multi-suite file is SUMMED, not truncated to the first",
-      ["10 tests executed"], rc=0)
+      [" 10 tests executed"], rc=0)
 def _(root):
     write(root, "multiTask", {"a.xml": SUITES_MULTI})
     return ["multiTask"]
 
 
 @case("skipped testcases are DEDUCTED from tests=",
-      ["178 tests executed"], rc=0)
+      [" 178 tests executed"], rc=0)
 def _(root):
     write(root, "skipTask", {"a.xml": SUITE_SKIPPED_SOME})
     return ["skipTask"]
@@ -193,7 +198,21 @@ def _(root):
     return ["negTask"]
 
 
-@case("happy path", ["3 tests executed"], rc=0)
+@case("skipped greater than tests is refused, not summed as negative",
+      ["skipped=10 exceeds tests=5"])
+def _(root):
+    write(root, "skipExceedsTask", {"a.xml": SUITE_SKIP_EXCEEDS})
+    return ["skipExceedsTask"]
+
+
+@case("an implausible count is refused rather than reported",
+      ["is implausible; refusing"])
+def _(root):
+    write(root, "hugeTask", {"a.xml": SUITE_IMPLAUSIBLE})
+    return ["hugeTask"]
+
+
+@case("happy path", [" 3 tests executed"], rc=0)
 def _(root):
     write(root, "goodTask", {"a.xml": SUITE_OK})
     return ["goodTask"]

--- a/.github/selftest_assert_guard.py
+++ b/.github/selftest_assert_guard.py
@@ -25,6 +25,16 @@ import sys
 import tempfile
 from pathlib import Path
 
+# This file ECHOES the guard's output, em dash included, so it needs the same
+# treatment as the guard: on cp1252 it printed the correct finding and then died
+# with UnicodeEncodeError while reporting it -- the bug it was written to catch,
+# in the reporter.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, OSError):  # pragma: no cover
+        pass
+
 GUARD = Path(__file__).resolve().parent / "assert_tests_executed.py"
 RESULTS = Path("hauler/build/test-results")
 
@@ -32,9 +42,21 @@ SUITE_OK = '<testsuite name="s" tests="3" failures="0"></testsuite>'
 SUITE_ZERO = '<testsuite name="s" tests="0" failures="0"></testsuite>'
 SUITE_TORN = '<testsuite name="s" tests="3"'  # truncated: unparseable
 SUITE_NOATTR = '<testsuite name="s" failures="0"></testsuite>'
+# EVERY fixture above is a single bare <testsuite> root. That is why a guard with
+# skip-deduction removed, and one that counts only the first suite, both passed
+# this harness green -- the shapes those defects live in were never fed to it.
+# A refusal-test whose fixtures cannot express a defect proves the guard is
+# UNCHANGED, not that it is correct.
+SUITES_MULTI = ('<testsuites><testsuite name="a" tests="4"/>'
+                '<testsuite name="b" tests="6"/></testsuites>')
+SUITES_ONE_NOATTR = ('<testsuites><testsuite name="a" tests="4"/>'
+                     '<testsuite name="b"/></testsuites>')
+SUITE_SKIPPED_SOME = '<testsuite name="s" tests="181" skipped="3"/>'
+SUITE_SKIPPED_ALL = '<testsuite name="s" tests="5" skipped="5"/>'
+SUITE_NEGATIVE = '<testsuite name="s" tests="-1"/>'
 
 # A literal, so that deleting a case is a RED rather than a smaller denominator.
-EXPECTED_STATES = 11
+EXPECTED_STATES = 16
 
 
 def write(root: Path, task: str, files: dict) -> None:
@@ -134,6 +156,41 @@ def _(root):
     # rather than a pass, and this harness notices when it does not.
     write(root, "goodTask", {"a.xml": SUITE_OK})
     return ["goodTask"]
+
+
+@case("multi-suite file is SUMMED, not truncated to the first",
+      ["10 tests executed"], rc=0)
+def _(root):
+    write(root, "multiTask", {"a.xml": SUITES_MULTI})
+    return ["multiTask"]
+
+
+@case("skipped testcases are DEDUCTED from tests=",
+      ["178 tests executed"], rc=0)
+def _(root):
+    write(root, "skipTask", {"a.xml": SUITE_SKIPPED_SOME})
+    return ["skipTask"]
+
+
+@case("a suite where EVERY test is skipped is not a pass",
+      ["report ZERO tests executed"])
+def _(root):
+    write(root, "allSkipTask", {"a.xml": SUITE_SKIPPED_ALL})
+    return ["allSkipTask"]
+
+
+@case("a sibling suite with no tests= poisons the file",
+      ["no tests= attribute", "subtotal"])
+def _(root):
+    write(root, "dropTask", {"a.xml": SUITES_ONE_NOATTR})
+    return ["dropTask"]
+
+
+@case("negative tests= is refused, not summed",
+      ["is not a plain non-negative integer"])
+def _(root):
+    write(root, "negTask", {"a.xml": SUITE_NEGATIVE})
+    return ["negTask"]
 
 
 @case("happy path", ["3 tests executed"], rc=0)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: SPIKE — prove the guard's REFUSAL paths on this runner
+        run: ./.github/selftest_assert_guard.py
+
       - name: Clear stale test results
         run: rm -rf hauler/build/test-results
       - name: Assemble, test, apiCheck, ktlint
@@ -88,6 +91,9 @@ jobs:
       # macosX64Test is expected to report SKIPPED: GitHub's macOS images are
       # Apple Silicon, so there is no x86 host to execute it on. Listed anyway so
       # the job log records whether that is true for this repo.
+      - name: SPIKE — prove the guard's REFUSAL paths on this runner
+        run: ./.github/selftest_assert_guard.py
+
       - name: Clear stale test results
         run: rm -rf hauler/build/test-results
       - name: Apple tests
@@ -121,6 +127,10 @@ jobs:
           java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+      - name: SPIKE — prove the guard's REFUSAL paths on this runner
+        shell: bash
+        run: ./.github/selftest_assert_guard.py
+
       - name: Clear stale test results
         shell: bash
         run: rm -rf hauler/build/test-results


### PR DESCRIPTION
> ## ✅ THIS SHOULD MERGE, after #37. The original banner said the opposite and was superseded on 2026-08-26.
>
> **It opened "⛔ DO NOT MERGE … will be closed unmerged", inherited from #54's precedent. That precedent does not transfer** — #54 had to be a throwaway because it deliberately broke the real guard on a CI leg. This one breaks nothing, runs in under a second, and closing it unmerged would delete the harness with the branch, re-enacting the exact defect #55 exists to record.
>
> ## 📋 MERGE SEQUENCE — written here because a status line that lived only in my focus already cost 38 hours
>
> **This PR is based on `ci/execute-untested-targets` (#37), not on `main`.** The order is not optional:
>
> ```
> 1.  #37 merges (SQUASH) -> its content lands on main under a NEW sha, branch deleted
> 2.  this PR's base disappears; rebase onto main and force-push
> 3.  ⚠️ ANY APPROVAL ON THIS PR DOES NOT SURVIVE THAT REBASE -- expected, not a regression
> 4.  re-request review at the new head
> ```
>
> **A green re-review here is NOT permission to land out of order.** If this merges first, #37's changes go to `main` twice under different SHAs.
>
> #37 must also SQUASH: `DO NOT MERGE` survives in commit messages `a4cc5d7` / `570cbd4` / `2d10ac5`, and a merge commit writes them into `main` permanently.

> Flagged here because a cross-repo review found the stale phrasing still standing, and because **"DO NOT MERGE" also appears in two COMMIT messages** (`a4cc5d7`, `570cbd4` on the base branch) — those land on `main` permanently. **Squash-merge with a clean message; a merge commit writes them into history.**

## What is established, and what is not

```
#54 established      the BASH guard's REFUSAL paths on three interpreters, by message
today's green shows  the PYTHON guard's HAPPY path on three runners
nobody has shown     the PYTHON guard's REFUSAL paths beyond ubuntu + local
```

**#53 was closed on measurements about `.github/assert-tests-executed.sh`, which was deleted an hour later.** The counts agreeing between the bash and Python versions on all five legs establishes that **the happy paths agree.** It says nothing about the refusals — those are different code.

**The transferable part:** *controls, spikes and closed follow-ups attach to an artifact, not to a filename.* A rewrite deletes its own evidence, and nothing notices, because the name did not change and the tests still pass.

## Why this is not ceremonial, and where it is aimed

The argument for skipping it would be that five of the six bash failure classes were **language semantics** — greedy BRE, collation ranges, octal arithmetic, wraparound, empty-glob under `set -u` — and Python's semantics are not platform-dependent that way. **That argument is sound and it does not cover the part that differs.**

**The refusal paths touch the filesystem, and Windows is where that differs.** Git Bash hands out `/c/Users/...` paths; Python resolves them through a different layer. The happy path proves resolution works **for a directory that exists**. The branch aimed at is:

> **`no results directory` — it could refuse for the *wrong reason* and look like a correct refusal.**

**A second, sharper one found while writing the harness.** The guard's messages contain a **non-ASCII em dash**:

```python
err(f"{task}: no results directory at {d} — cannot determine whether it ran.")
```

A console codepage that cannot encode it raises inside `print`, hits the top-level `except`, and **still exits 1**. A correct-looking red carrying the wrong text — **invisible to any exit-code check**, and Windows-shaped. The harness asserts `"crashed:"` is absent for exactly this.

## The harness

`.github/selftest_assert_guard.py` drives **10 states** and asserts **each branch's own message**, not its exit code:

| state | asserted text |
|---|---|
| no results directory | `no results directory at`, `NOT a pass` |
| directory but no XML | `contains NO XML`, `did not report at all` |
| all XML unparseable | `NONE parseable`, `PARSER failure` |
| partial parse | `only 1 of 2`, `PARTIAL PARSE` |
| `tests=` not an integer | `is not an integer` |
| no `tests=` attribute | `no <testsuite tests=...> attribute` |
| parsed cleanly, zero tests | `report ZERO tests executed` |
| no task names | `called with no task names` |
| good task **then** phantom | both messages — the v3 unwind shape |
| happy path | `3 tests executed`, exit 0 |

**The count of states driven is asserted.** A state that never ran and a state that ran correctly produce identical output otherwise.

## ⚠️ Proven able to FAIL before being wired in

A harness that has only ever passed is the thing this repo keeps finding. Three deliberate mutations, on **copies in a `mktemp -d` sandbox** — never the tracked file:

```
reword "no results directory at"   -> FAIL  2 cases, "missing text"
ZERO branch returns True           -> FAIL  "exit 0, expected 1"
guard raises mid-check             -> FAIL  "guard CRASHED"
unmutated control                  -> 10/10 pass, exit 0
```

**The third is the one that matters.** The crashing guard **still exited 1** — an exit-code check would have called it a correct refusal. Only the message assertion separated them. That is #55's entire premise, demonstrated rather than argued.

## Reading the result

The step runs **before** the build on each leg, so it reports even if Gradle fails, and the three legs are independent. What to look for:

- **`All 10 states behaved as specified on <platform>`** on `check`, `apple` and `windows` → the refusal paths are proven on all three, and #55 closes.
- **Any `FAIL` line** → a refusal branch does not behave as specified on that platform. That is a real finding and the guard needs fixing before #37 merges.
- **`drove only N of 10 states`** → the harness itself is broken; trust nothing else in its output.

Then: record the logs on #55 and **close this PR unmerged.**


