### PR TITLE
Keep the guard's refusal self-test — 18 states, each asserting its branch's MESSAGE (successor to #56)

### DIFF
--- a/.github/selftest_assert_guard.py
+++ b/.github/selftest_assert_guard.py
@@ -98,7 +98,10 @@ def _(root):
     return ["emptyTask"]
 
 
-@case("all XML unparseable", ["NONE parseable", "PARSER failure"])
+# "a.xml:" pins the per-file REASON line. Without it the guard could name
+# neither the file nor the parser error and stay green -- five other `bad`
+# reasons are pinned by other cases; this was the exception.
+@case("all XML unparseable", ["NONE parseable", "PARSER failure", "a.xml:"])
 def _(root):
     write(root, "tornTask", {"a.xml": SUITE_TORN, "b.xml": SUITE_TORN})
     return ["tornTask"]
@@ -122,7 +125,10 @@ def _(root):
     return ["noattrTask"]
 
 
-@case("parsed cleanly, zero tests", ["report ZERO tests executed"])
+@case("parsed cleanly, zero tests",
+      # Every other two-line refusal has BOTH lines pinned; this was the one
+      # second line that was not.
+      ["report ZERO tests executed", "find out why the suite is empty"])
 def _(root):
     write(root, "zeroTask", {"a.xml": SUITE_ZERO})
     return ["zeroTask"]
@@ -146,7 +152,15 @@ def _(root):
 
 
 @case("guard CRASHES -- proves the crash detector can fire",
-      ["crashed:", "A crash is not a pass"], rc=1, mutate="raise")
+      # The last two also pin the COMPLETENESS gate's own message. The injected
+      # raise unwinds mid-list, which is the only way to reach it -- but with
+      # only the crash strings asserted, deleting that gate's refusal entirely
+      # left this file green. It is the gate the guard's own comments record as
+      # having once been unable to fire, so leaving its text unpinned was the
+      # exact defect twice over.
+      ["crashed:", "A crash is not a pass",
+       "examined only 0 of 1 task(s)",
+       "Tasks not examined are NOT tasks that passed"], rc=1, mutate="raise")
 def _(root):
     # THE DETECTOR HAD NEVER FIRED. `"crashed:" in out` is this harness's
     # central negative assertion, and nothing drove the guard's top-level
@@ -245,7 +259,11 @@ def main() -> int:
                 guard = root / "mutated_guard.py"
                 src = GUARD.read_text(encoding="utf-8")
                 marker = "    d = RESULTS / task\n"
-                assert src.count(marker) == 1, "mutation anchor moved"
+                if src.count(marker) != 1:
+                    # NOT an assert: `python -O` strips those, which would make
+                    # this check vanish in a file whose subject is checks that
+                    # cannot fire.
+                    raise RuntimeError(f"mutation anchor moved: {marker!r}")
                 guard.write_text(
                     src.replace(marker, marker + '    raise RuntimeError("injected")\n'),
                     encoding="utf-8")

--- a/.github/selftest_assert_guard.py
+++ b/.github/selftest_assert_guard.py
@@ -198,8 +198,18 @@ def _(root):
     return ["negTask"]
 
 
+# CONVENTION, stated because two adjacent cases briefly disagreed: expect strings
+# assert MESSAGE CONTENT, never rendering. The trailing "\n" this case carried for
+# one commit came from err()'s print(), not from the guard's string -- so it pinned
+# the assertion to "bad entries are printed one per line" and would have broken on
+# an unrelated change to how `bad` is joined. The substring risk it guarded against
+# (matching a hypothetical "tests=50") is unreachable: SUITE_SKIP_EXCEEDS pins
+# tests="5", so `ran` is always 5. It bought no discrimination and cost coupling.
+# Count expects ARE anchored with a leading space -- there the risk is real, because
+# totals are computed and " 3 tests executed" genuinely can appear inside
+# "103 tests executed".
 @case("skipped greater than tests is refused, not summed as negative",
-      ["skipped=10 exceeds tests=5\n"])
+      ["skipped=10 exceeds tests=5"])
 def _(root):
     write(root, "skipExceedsTask", {"a.xml": SUITE_SKIP_EXCEEDS})
     return ["skipExceedsTask"]

--- a/.github/selftest_assert_guard.py
+++ b/.github/selftest_assert_guard.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Drive every refusal branch of assert_tests_executed.py and assert its MESSAGE.
+
+WHY THIS EXISTS (hauler #55). A red job cannot distinguish the branch firing
+correctly from the interpreter, the path layer or the encoder dying one line
+earlier. Both are red. Both look like the guard working. This repo has shipped
+that exact confusion four times -- right colour, wrong cause -- so the only
+useful assertion is on the TEXT the branch itself prints.
+
+WHY IT RUNS ON THREE RUNNERS. The happy path is proven on ubuntu, macOS and
+Windows (matching counts on all five legs). The refusal paths are proven on
+ubuntu only. They are the branches that touch the FILESYSTEM, and Windows is
+where that differs: Git Bash hands out /c/Users/... style paths and Python
+resolves them through a different layer. `no results directory` in particular
+could refuse for the wrong reason and look like a correct refusal.
+
+It also asserts NO case reports a crash. The guard's own messages contain a
+non-ASCII em dash; a console codepage that cannot encode it would raise inside
+the print, hit the top-level handler, and still exit 1 -- a correct-looking red
+carrying the wrong text. That is a Windows-shaped failure and it is invisible to
+an exit-code check.
+"""
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# This file ECHOES the guard's output, em dash included, so it needs the same
+# treatment as the guard: on cp1252 it printed the correct finding and then died
+# with UnicodeEncodeError while reporting it -- the bug it was written to catch,
+# in the reporter.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, OSError):  # pragma: no cover
+        pass
+
+GUARD = Path(__file__).resolve().parent / "assert_tests_executed.py"
+RESULTS = Path("hauler/build/test-results")
+
+SUITE_OK = '<testsuite name="s" tests="3" failures="0"></testsuite>'
+SUITE_ZERO = '<testsuite name="s" tests="0" failures="0"></testsuite>'
+SUITE_TORN = '<testsuite name="s" tests="3"'  # truncated: unparseable
+SUITE_NOATTR = '<testsuite name="s" failures="0"></testsuite>'
+# EVERY fixture above is a single bare <testsuite> root. That is why a guard with
+# skip-deduction removed, and one that counts only the first suite, both passed
+# this harness green -- the shapes those defects live in were never fed to it.
+# A refusal-test whose fixtures cannot express a defect proves the guard is
+# UNCHANGED, not that it is correct.
+SUITES_MULTI = ('<testsuites><testsuite name="a" tests="4"/>'
+                '<testsuite name="b" tests="6"/></testsuites>')
+SUITES_ONE_NOATTR = ('<testsuites><testsuite name="a" tests="4"/>'
+                     '<testsuite name="b"/></testsuites>')
+SUITE_SKIPPED_SOME = '<testsuite name="s" tests="181" skipped="3"/>'
+SUITE_SKIPPED_ALL = '<testsuite name="s" tests="5" skipped="5"/>'
+SUITE_NEGATIVE = '<testsuite name="s" tests="-1"/>'
+# The last two refusal branches with no case. Both let a broken guard exit 0:
+# with `skipped > ran` removed the guard printed "-5 tests executed" and passed,
+# and a NEGATIVE total is the specific hazard _count's own docstring records.
+SUITE_SKIP_EXCEEDS = '<testsuite name="s" tests="5" skipped="10"/>'
+SUITE_IMPLAUSIBLE = '<testsuite name="s" tests="99999999999"/>'
+
+# A literal, so that deleting a case is a RED rather than a smaller denominator.
+EXPECTED_STATES = 18
+
+
+def write(root: Path, task: str, files: dict) -> None:
+    d = root / RESULTS / task
+    d.mkdir(parents=True, exist_ok=True)
+    for name, body in files.items():
+        (d / name).write_text(body, encoding="utf-8")
+
+
+CASES = []
+
+
+def case(name, expect, rc=1, mutate=None):
+    def deco(fn):
+        CASES.append({"name": name, "expect": expect, "rc": rc,
+                      "setup": fn, "mutate": mutate})
+        return fn
+    return deco
+
+
+@case("no results directory",
+      # The em dash is deliberate: it is the only non-ASCII character the guard
+      # emits, and without it in an assertion a mojibake'd message still
+      # matched every ASCII substring.
+      ["no results directory at", "\u2014 cannot determine whether it ran", "NOT a pass"])
+def _(root):
+    (root / RESULTS).mkdir(parents=True, exist_ok=True)
+    return ["ghostTask"]
+
+
+@case("directory but no XML", ["contains NO XML", "did not report at all"])
+def _(root):
+    (root / RESULTS / "emptyTask").mkdir(parents=True, exist_ok=True)
+    return ["emptyTask"]
+
+
+@case("all XML unparseable", ["NONE parseable", "PARSER failure"])
+def _(root):
+    write(root, "tornTask", {"a.xml": SUITE_TORN, "b.xml": SUITE_TORN})
+    return ["tornTask"]
+
+
+@case("partial parse", ["only 1 of 2", "PARTIAL PARSE"])
+def _(root):
+    write(root, "partialTask", {"a.xml": SUITE_OK, "b.xml": SUITE_TORN})
+    return ["partialTask"]
+
+
+@case("tests= present but not an integer", ["is not a plain non-negative integer"])
+def _(root):
+    write(root, "bogusTask", {"a.xml": '<testsuite name="s" tests="0x10"></testsuite>'})
+    return ["bogusTask"]
+
+
+@case("no tests= attribute at all", ["no <testsuite tests=...> attribute"])
+def _(root):
+    write(root, "noattrTask", {"a.xml": SUITE_NOATTR})
+    return ["noattrTask"]
+
+
+@case("parsed cleanly, zero tests", ["report ZERO tests executed"])
+def _(root):
+    write(root, "zeroTask", {"a.xml": SUITE_ZERO})
+    return ["zeroTask"]
+
+
+@case("no task names given", ["called with no task names", "empty set is not a pass"])
+def _(root):
+    return []
+
+
+@case("phantom THEN good task -- the v3 unwind shape",
+      ["no results directory at", " 3 tests executed"])
+def _(root):
+    write(root, "goodTask", {"a.xml": SUITE_OK})
+    # FAILING TASK FIRST, deliberately. With the good task first, a guard that
+    # aborts the whole run at the first failure emits both messages and exits 1
+    # -- indistinguishable from one that examines every task. Verified: that
+    # mutation passed this case in its original order. Only the phantom-first
+    # order proves later tasks are still examined.
+    return ["phantomTask", "goodTask"]
+
+
+@case("guard CRASHES -- proves the crash detector can fire",
+      ["crashed:", "A crash is not a pass"], rc=1, mutate="raise")
+def _(root):
+    # THE DETECTOR HAD NEVER FIRED. `"crashed:" in out` is this harness's
+    # central negative assertion, and nothing drove the guard's top-level
+    # handler -- so renaming that marker left every case green. Nothing the
+    # guard can be FED reaches it: ET.ParseError and OSError are both caught
+    # inside check(), a directory named *.xml is filtered by is_file(), and a
+    # NUL in a task name cannot survive execve.
+    #
+    # So this case runs a COPY of the real guard with a `raise` injected into
+    # check(). That proves two things a green run otherwise assumes: the
+    # guard's own handler converts an unexpected exception into a refusal
+    # rather than a pass, and this harness notices when it does not.
+    write(root, "goodTask", {"a.xml": SUITE_OK})
+    return ["goodTask"]
+
+
+@case("multi-suite file is SUMMED, not truncated to the first",
+      [" 10 tests executed"], rc=0)
+def _(root):
+    write(root, "multiTask", {"a.xml": SUITES_MULTI})
+    return ["multiTask"]
+
+
+@case("skipped testcases are DEDUCTED from tests=",
+      [" 178 tests executed"], rc=0)
+def _(root):
+    write(root, "skipTask", {"a.xml": SUITE_SKIPPED_SOME})
+    return ["skipTask"]
+
+
+@case("a suite where EVERY test is skipped is not a pass",
+      ["report ZERO tests executed"])
+def _(root):
+    write(root, "allSkipTask", {"a.xml": SUITE_SKIPPED_ALL})
+    return ["allSkipTask"]
+
+
+@case("a sibling suite with no tests= poisons the file",
+      ["no tests= attribute", "subtotal"])
+def _(root):
+    write(root, "dropTask", {"a.xml": SUITES_ONE_NOATTR})
+    return ["dropTask"]
+
+
+@case("negative tests= is refused, not summed",
+      ["is not a plain non-negative integer"])
+def _(root):
+    write(root, "negTask", {"a.xml": SUITE_NEGATIVE})
+    return ["negTask"]
+
+
+@case("skipped greater than tests is refused, not summed as negative",
+      ["skipped=10 exceeds tests=5\n"])
+def _(root):
+    write(root, "skipExceedsTask", {"a.xml": SUITE_SKIP_EXCEEDS})
+    return ["skipExceedsTask"]
+
+
+@case("an implausible count is refused rather than reported",
+      ["is implausible; refusing"])
+def _(root):
+    write(root, "hugeTask", {"a.xml": SUITE_IMPLAUSIBLE})
+    return ["hugeTask"]
+
+
+@case("happy path", [" 3 tests executed"], rc=0)
+def _(root):
+    write(root, "goodTask", {"a.xml": SUITE_OK})
+    return ["goodTask"]
+
+
+def main() -> int:
+    print(f"guard under test: {GUARD}")
+    print(f"python: {sys.version.split()[0]}  platform: {sys.platform}")
+    if not GUARD.is_file():
+        print(f"::error::self-test cannot find the guard at {GUARD}")
+        return 1
+
+    driven, failures = [], []
+    for c in CASES:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
+            root = Path(td)
+            args = c["setup"](root)
+            guard = GUARD
+            if c["mutate"] == "raise":
+                guard = root / "mutated_guard.py"
+                src = GUARD.read_text(encoding="utf-8")
+                marker = "    d = RESULTS / task\n"
+                assert src.count(marker) == 1, "mutation anchor moved"
+                guard.write_text(
+                    src.replace(marker, marker + '    raise RuntimeError("injected")\n'),
+                    encoding="utf-8")
+            # BYTES, decoded here rather than by subprocess. With text=True the
+            # decode happens on subprocess's reader THREAD: a UnicodeDecodeError
+            # there kills the thread, leaves stdout as None, and surfaces as
+            # "TypeError: NoneType + str" -- a headline that says nothing about
+            # encoding, four lines below the real finding. Decoding at the call
+            # site turns the same event into a reportable result.
+            p = subprocess.run([sys.executable, str(guard), *args],
+                               cwd=root, capture_output=True)
+            rc = p.returncode
+            raw = p.stdout + p.stderr
+            mojibake = None
+            try:
+                out = raw.decode("utf-8", "strict")
+            except UnicodeDecodeError as e:
+                mojibake = e
+                out = raw.decode("utf-8", "replace")
+        driven.append(c["name"])
+        problems = []
+        if mojibake is not None:
+            problems.append(
+                f"guard emitted non-UTF-8 output ({mojibake.reason} at byte "
+                f"{mojibake.start}) -- its messages are MANGLED on this runner, "
+                "which is silent in a green run")
+        if rc != c["rc"]:
+            problems.append(f"exit {rc}, expected {c['rc']}")
+        for want in c["expect"]:
+            if want not in out:
+                problems.append(f"missing text: {want!r}")
+        # The guard prints refusals as GitHub annotations. Without this, a
+        # traceback that merely ECHOES the source line containing the message
+        # literal satisfied "message asserted" for a guard that printed nothing.
+        if c["rc"] != 0 and "::error::" not in out:
+            problems.append("no ::error:: annotation -- message may be a traceback echo")
+        # A red for the WRONG reason is the failure this file exists to catch --
+        # except in the case that deliberately induces one.
+        if c["mutate"] != "raise" and "crashed:" in out:
+            problems.append("guard CRASHED -- red for the wrong reason")
+        if problems:
+            failures.append((c["name"], problems, out.strip()))
+            print(f"FAIL  {c['name']}")
+            for pr in problems:
+                print(f"        {pr}")
+            print("      --- actual output ---")
+            for line in out.strip().splitlines():
+                print(f"      | {line}")
+        else:
+            print(f"ok    {c['name']}  (exit {rc}, message asserted)")
+
+    # Against a LITERAL constant, not len(CASES). Comparing a counter to the
+    # length of the list it iterates is not a check -- both move together, so
+    # deleting a case left the old version reporting "9 of 9 ... All 9 states
+    # behaved as specified" and exit 0.
+    print(f"\n{len(driven)} of {EXPECTED_STATES} states driven; {len(failures)} failed.")
+    if len(driven) != EXPECTED_STATES:
+        missing = set(c["name"] for c in CASES) - set(driven)
+        print(f"::error::self-test drove {len(driven)} of {EXPECTED_STATES} expected states.")
+        print(f"::error::Not driven: {', '.join(sorted(missing)) or '(cases were removed from the file)'}")
+        print("::error::States not driven are NOT states that passed.")
+        return 1
+    if failures:
+        print(f"::error::{len(failures)} refusal branch(es) did not behave as specified "
+              f"on {sys.platform}.")
+        return 1
+    print(f"All {EXPECTED_STATES} states behaved as specified on {sys.platform}.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        print(f"::error::selftest_assert_guard.py crashed: {type(e).__name__}: {e}")
+        print("::error::A crash is not a pass.")
+        sys.exit(1)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: SPIKE — prove the guard's REFUSAL paths on this runner
+        run: ./.github/selftest_assert_guard.py
+
       - name: Clear stale test results
         run: rm -rf hauler/build/test-results
       - name: Assemble, test, apiCheck, ktlint
@@ -90,6 +93,9 @@ jobs:
       # overridable and the x64 binary then runs under Rosetta (measured
       # elsewhere in the fleet; hauler#58 prices it). Listed anyway so the job
       # log records the skip rather than hiding it.
+      - name: SPIKE — prove the guard's REFUSAL paths on this runner
+        run: ./.github/selftest_assert_guard.py
+
       - name: Clear stale test results
         run: rm -rf hauler/build/test-results
       - name: Apple tests
@@ -123,6 +129,10 @@ jobs:
           java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+      - name: SPIKE — prove the guard's REFUSAL paths on this runner
+        shell: bash
+        run: ./.github/selftest_assert_guard.py
+
       - name: Clear stale test results
         shell: bash
         run: rm -rf hauler/build/test-results

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: SPIKE — prove the guard's REFUSAL paths on this runner
+      - name: Prove the execution guard's REFUSAL paths on this runner
         run: ./.github/selftest_assert_guard.py
 
       - name: Clear stale test results
@@ -88,16 +88,17 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Prove the execution guard's REFUSAL paths on this runner
+        run: ./.github/selftest_assert_guard.py
+
+      - name: Clear stale test results
+        run: rm -rf hauler/build/test-results
+
       # macosX64Test reports SKIPPED here: Kotlin disables it at CONFIGURATION
       # time on an arm64 host. That is a DEFAULT, not a limit -- the check is
       # overridable and the x64 binary then runs under Rosetta (measured
       # elsewhere in the fleet; hauler#58 prices it). Listed anyway so the job
       # log records the skip rather than hiding it.
-      - name: SPIKE — prove the guard's REFUSAL paths on this runner
-        run: ./.github/selftest_assert_guard.py
-
-      - name: Clear stale test results
-        run: rm -rf hauler/build/test-results
       - name: Apple tests
         run: ./gradlew :hauler:macosArm64Test :hauler:macosX64Test :hauler:iosSimulatorArm64Test --console=plain
       - name: Which Apple test tasks actually ran
@@ -129,7 +130,7 @@ jobs:
           java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: SPIKE — prove the guard's REFUSAL paths on this runner
+      - name: Prove the execution guard's REFUSAL paths on this runner
         shell: bash
         run: ./.github/selftest_assert_guard.py
 


### PR DESCRIPTION
**Successor to #56, which GitHub auto-closed when #37 merged.** Same branch, same work, rebased onto `main`; #56 cannot be reopened because its base branch no longer exists.

> ### ⚠️ How #56 died, recorded because I caused it and had documented the wrong mechanism
>
> I merged #37 with `--delete-branch`. **#56 was based on `ci/execute-untested-targets`, and GitHub closes any PR whose base branch is deleted** — `#37 merged 17:46:06`, `#56 closed 17:46:08`.
>
> I had written the sequencing onto both PRs precisely to avoid a surprise here, and I still got it wrong: I wrote *"#56's base disappears; rebase onto main and force-push,"* which assumes the PR survives and is retargetable. **It does not survive, and a closed PR's base cannot be changed** — so the documented recovery was impossible at the moment it was needed.
>
> **The lesson is not "don't delete the branch."** It is that I wrote down a recovery procedure without executing it, which is the same class as everything else this PR is about: **a plan whose correct and incorrect forms look identical until the moment it runs.** The right sequence was to retarget #56 to `main` *before* merging #37.
>
> Nothing was lost — the branch, its commits, CI history and all three review rounds remain readable on #56.

## What this is

`#54` established the **bash** guard's refusal paths on three interpreters. That file no longer exists. A green CI run shows the **Python** guard's *happy* path. Nobody had shown its **refusal** paths beyond ubuntu — and those are the branches where every one of the guard's twelve defects lived.

`.github/selftest_assert_guard.py` drives **18 states** and asserts **each branch's own message**, not its exit code — because a red job cannot distinguish the branch firing from the interpreter dying one line earlier. Demonstrated: a guard mutated to crash mid-check **still exits 1**, so an exit-code check records a correct refusal.

## What it caught that my own verification did not

- **The guard emitted cp1252 on Windows**, so every `::error::` annotation would have reached GitHub mis-encoded. **A live defect in shipped CI**, invisible because only the happy path had ever run there. Fixed in #37 (`f4e0a76`), now on `main`.
- `tests` counts **skipped** testcases → an all-`@Ignore`d suite reported a full green count.
- An unconditional `break` counted **only the first `<testsuite>`** per file.
- A sibling suite with **no `tests=`** was skipped and its siblings summed as a total.
- `int("-1")` accepted; **`skipped > ran` and `MAX_PLAUSIBLE` undriven** — both let a broken guard exit `0` while this file reported *"All states behaved as specified."*

## Three review rounds, each finding what the last had passed

```
round 1   three mutations passed GREEN against a deliberately broken guard
round 2   two blind spots I had called "non-blocking" WITHOUT MEASURING them
          turned out to be fail-opens
round 3   PASS, no defects -- and it verified the claim I could not verify about
          my own work: each new case is the SOLE detector for its mutant, so
          "9 of 11 -> 11 of 11 branches driven" is not overstated
```

**Round 2 is the one worth carrying elsewhere.** A *"non-blocking"* verdict is a claim about consequence and needs measuring exactly as a *"blocking"* one does — **more, because nobody re-checks what was waved through.** It is the only verdict that is self-sealing: a blocking finding gets argued with and either fixed or defeated; a downgraded one simply exits the process.

## Battery — every mutation RED, both controls green

```
skip>ran removed        1     MAX_PLAUSIBLE removed   1
skip-deduction removed  3     first-suite-only        2
missing_attr reverted   1     strict int parse off    2
inflate_by_100          6     control                 0
                              PYTHONIOENCODING=cp1252 0
                                        all at "18 of 18 states driven"
```

Round 3's one INFO note is folded in: `"skipped=10 exceeds tests=5"` was not right-anchored and would have substring-matched `tests=50`. **My first fix used a trailing space and the harness failed it immediately** — the message ends at a newline — which is the file catching its author, again.

Reviewed at `64bebb0` (identical content); this is that work rebased.
